### PR TITLE
add default name constant

### DIFF
--- a/plugin/set.go
+++ b/plugin/set.go
@@ -13,6 +13,10 @@ import (
 	"github.com/hashicorp/packer/version"
 )
 
+// Use this name to make the name of the plugin in the packer template match
+// the multiplugin suffix, instead of requirng a second part.
+const DEFAULT_NAME = "-packer-default-plugin-name-"
+
 // Set is a plugin set. It's API is meant to be very close to what is returned
 // by plugin.Server
 // It can describe itself or run a single plugin using the CLI arguments.

--- a/plugin/set.go
+++ b/plugin/set.go
@@ -14,8 +14,14 @@ import (
 )
 
 // Use this name to make the name of the plugin in the packer template match
-// the multiplugin suffix, instead of requirng a second part.
+// the multiplugin suffix, instead of requiring a second part.
+// For example, calling :
+//  pps.RegisterProvisioner(plugin.DEFAULT_NAME, new(CommentProvisioner))
+// On a plugin named `packer-plugin-foo`, will make the `foo` provisioner available
+// with your CommentProvisioner doing that. There can only be one unnamed
+// plugin per plugin type.
 const DEFAULT_NAME = "-packer-default-plugin-name-"
+
 
 // Set is a plugin set. It's API is meant to be very close to what is returned
 // by plugin.Server


### PR DESCRIPTION
This is a sister PR to one in the packer core repo to make multiplugin sets capable of using a "default" plugin. This string constant will allow users to register a single specialized plugin that uses the root name of a plugin rather than a compound name. 

For example, if I have a plugin named "packer-plugin-comment", I can register the plugin using the name "foo" in that plugin's main.go: 

```go
pps.RegisterProvisioner("foo", new(CommentProvisioner))
```

and invoke the plugin in my packer template using `"type": "comment-foo"`

If I want, I can use this string constant instead to register the plugin:

```go 
pps.RegisterProvisioner(plugin.DEFAULT_NAME, new(CommentProvisioner))
```

By registering the plugin using this string constant instead of "foo"; this will allow me to invoke the plugin in my packer template using `"type": "comment"`

Using a complex string constant available in the plugin library means users know what they're doing rather than assuming users know how to configure it properly using some magical documented string like "default" or "-"

Must be merged before #https://github.com/hashicorp/packer/pull/10410