### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Go Reference](https://pkg.go.dev/badge/github.com/hashicorp/packer-plugin-sdk/.svg)](https://pkg.go.dev/github.com/hashicorp/packer-plugin-sdk/)
+
 # Packer Plugin SDK
 
 This SDK enables building Packer plugins. This allows Packer's users to use both the officially-supported builders, provisioners, and post-processors, and custom in-house solutions.
@@ -43,7 +45,7 @@ See the [Extending Packer](https://www.packer.io/docs/extending) section on the 
 
 ## Migrating to SDK from built-in SDK
 
-Migrating to the standalone SDK v1 is covered on the [Plugin SDK section](https://www.packer.io/docs/extend/plugin-sdk.html) of the website.
+Migrating to the standalone SDK v1 is covered on the [Plugin SDK section](https://packer-git-master.hashicorp.vercel.app/guides/1.7-plugin-upgrade) of the website.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -49,66 +49,6 @@ Migrating to the standalone SDK v1 is covered on the [Plugin SDK section](https:
 
 The Packer Plugin SDK is a [Go module](https://github.com/golang/go/wiki/Modules) versioned using [semantic versioning](https://semver.org/).
 
-## Releasing
-
-The Packer Plugin SDK is distributed as a Go module, so a minimal 'release' is just a git tag on main.
-
-Releases can be triggered via CircleCI, or the release scripts run from one's own machine.
-
-### Releasing via CircleCI
-
-
-#### Changelog
-
-`CHANGELOG.md` on the `main` branch must have a line of the following form:
-```
-## x.y.z (Upcoming)
-```
-where `x.y.z` is the SDK version you intend to release.
-
-
-Underneath the `# x.y.z (Upcoming)` heading, please write human-readable entries describing the changes made in this version.
-
-### Triggering a release
-
-All commits to `main` trigger the `release` workflow on CircleCI, but manual approval is needed to proceed with the workflow.
-
-#### Find all `main` workflows
-
-Go to https://circleci.com/gh/hashicorp/workflows/packer-plugin-sdk/tree/main and click on the latest workflow.
-
-It should show the latest `main` commit, which may be updates to the CHANGELOG.
-
-The status should be `ON HOLD`.
-
-#### Approve the `trigger-release` job
-
-Find the `trigger-release` job on the workflow diagram, click on it, and click Approve.
-
-#### Verify
-
-The workflow will then run several other jobs to test and perform the release.
-
-The main steps performed by the `release.sh` script are:
- - CHANGELOG.md: remove `(Upcoming)` and commit changes
- - tag `vx.y.z`
- - push to `main`
-
-Verify that this has taken place correctly by inspecting the `main` branch once the release is complete.
-### Releasing manually
-
-### Prerequisites
-
-Same as above in the CircleCI process.
-
-### Releasing
-
-Check out `main` locally and pull.
-
-Run `make test` and any other steps you need to satisfy yourself that the release works.
-
-Run `./scripts/release.sh`.
-
 ## Contributing
 
 See [`.github/CONTRIBUTING.md`](https://github.com/hashicorp/packer-plugin-sdk/blob/master/.github/CONTRIBUTING.md)

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -70,9 +70,9 @@ function changelogMain {
 
 function modifyVersionFiles {
   printf "Modifying version files..."
-  sed -i "s/const Version =.*/const Version = \"${TARGET_VERSION_CORE}\"/" version/version.go
+  sed -i "s/var Version =.*/var Version = \"${TARGET_VERSION_CORE}\"/" version/version.go
   ## Set pre-release version to empty string
-  sed -i "s/const VersionPrerelease =.*/const VersionPrerelease = \"\"/" version/version.go
+  sed -i "s/var VersionPrerelease =.*/var VersionPrerelease = \"\"/" version/version.go
 }
 
 function commitChanges {
@@ -80,7 +80,6 @@ function commitChanges {
   modifyVersionFiles
   git add version/version.go
 
-	## Enable GPG Signing on commits
 	if [ "$CI" == true ]; then
     git commit --gpg-sign="${GPG_KEY_ID}" -m "v${TARGET_VERSION} [skip ci]"
     git tag -a -m "v${TARGET_VERSION}" -s -u "${GPG_KEY_ID}" "v${TARGET_VERSION}"

--- a/version/version.go
+++ b/version/version.go
@@ -12,19 +12,17 @@ import (
 // The git commit that was compiled. This will be filled in by the compiler.
 var GitCommit string
 
-var (
-	// Package version helps plugin creators set and track the sdk version using
-	Version = "0.0.9"
+// Package version helps plugin creators set and track the sdk version using
+var Version = "0.0.9"
 
-	// A pre-release marker for the version. If this is "" (empty string)
-	// then it means that it is a final release. Otherwise, this is a pre-release
-	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+// A pre-release marker for the version. If this is "" (empty string)
+// then it means that it is a final release. Otherwise, this is a pre-release
+// such as "dev" (in development), "beta", "rc1", etc.
+var VersionPrerelease = "dev"
 
-	// SDKVersion is used by the plugin set to allow Packer to recognize
-	// what version of the sdk the plugin is.
-	SDKVersion = InitializePluginVersion(Version, VersionPrerelease)
-)
+// SDKVersion is used by the plugin set to allow Packer to recognize
+// what version of the sdk the plugin is.
+var SDKVersion = InitializePluginVersion(Version, VersionPrerelease)
 
 // InitializePluginVersion initializes the SemVer and returns a version var.
 // If the provided "version" string is not valid, the call to version.Must


### PR DESCRIPTION
* Add pkg.go.dev badge
* Add temporary link to 1.7 plugin migration guide; using a temporary link unit the guide goes live on Packer.io