### PR TITLE
Add generic plugin acc test

### DIFF
--- a/acctest/pluginacc.go
+++ b/acctest/pluginacc.go
@@ -10,13 +10,13 @@ import (
 	"testing"
 )
 
-// DatasourceTestCase is a single set of tests to run for a data source.
-// A DatasourceTestCase should generally map 1:1 to each test method for your
+// PluginTestCase is a single set of tests to run for a plugin.
+// A PluginTestCase should generally map 1:1 to each test method for your
 // acceptance tests.
 // Requirements:
 // - The plugin to be tested must be previously installed so that Packer can discover it.
-// - Packer must be installed
-type DatasourceTestCase struct {
+// - Packer must also be installed
+type PluginTestCase struct {
 	// Check is called after this step is executed in order to test that
 	// the step executed successfully. If this is not set, then the next
 	// step will be called
@@ -36,12 +36,12 @@ type DatasourceTestCase struct {
 	Teardown TestTeardownFunc
 	// Template is the testing HCL2 template to use.
 	Template string
-	// Type is the type of data source.
+	// Type is the type of the plugin.
 	Type string
 }
 
 //nolint:errcheck
-func TestDatasource(t *testing.T, testCase *DatasourceTestCase) {
+func TestPlugin(t *testing.T, testCase *PluginTestCase) {
 	if os.Getenv(TestEnvVar) == "" {
 		t.Skip(fmt.Sprintf(
 			"Acceptance tests skipped unless env '%s' set",
@@ -89,7 +89,7 @@ func TestDatasource(t *testing.T, testCase *DatasourceTestCase) {
 	if testCase.Check != nil {
 		checkErr = testCase.Check(buildCommand, logfile)
 	}
-	// Clean up anything created in data source run
+	// Clean up anything created in the plugin run
 	if testCase.Teardown != nil {
 		cleanErr := testCase.Teardown()
 		if cleanErr != nil {
@@ -100,7 +100,7 @@ func TestDatasource(t *testing.T, testCase *DatasourceTestCase) {
 	// Fail test if check failed.
 	if checkErr != nil {
 		cwd, _ := os.Getwd()
-		t.Fatalf(fmt.Sprintf("Error running data source acceptance"+
+		t.Fatalf(fmt.Sprintf("Error running plugin acceptance"+
 			" tests: %s\nLogs can be found at %s\nand the "+
 			"acceptance test template can be found at %s",
 			checkErr.Error(), filepath.Join(cwd, logfile),

--- a/acctest/pluginacc.go
+++ b/acctest/pluginacc.go
@@ -38,6 +38,9 @@ type PluginTestCase struct {
 	Template string
 	// Type is the type of the plugin.
 	Type string
+	// The extension of the template: .json or .pkr.hcl
+	// Defaults to .pkr.hcl
+	Extension string
 }
 
 //nolint:errcheck
@@ -57,7 +60,11 @@ func TestPlugin(t *testing.T, testCase *PluginTestCase) {
 	}
 
 	logfile := fmt.Sprintf("packer_log_%s.txt", testCase.Name)
-	templatePath := fmt.Sprintf("./%s.pkr.hcl", testCase.Name)
+
+	if testCase.Extension == "" {
+		testCase.Extension = ".pkr.hcl"
+	}
+	templatePath := fmt.Sprintf("./%s%s", testCase.Name, testCase.Extension)
 
 	// Write config hcl2 template
 	out := bytes.NewBuffer(nil)

--- a/acctest/pluginacc.go
+++ b/acctest/pluginacc.go
@@ -2,6 +2,7 @@ package acctest
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -38,9 +39,6 @@ type PluginTestCase struct {
 	Template string
 	// Type is the type of the plugin.
 	Type string
-	// The extension of the template: .json or .pkr.hcl
-	// Defaults to .pkr.hcl
-	Extension string
 }
 
 //nolint:errcheck
@@ -61,10 +59,11 @@ func TestPlugin(t *testing.T, testCase *PluginTestCase) {
 
 	logfile := fmt.Sprintf("packer_log_%s.txt", testCase.Name)
 
-	if testCase.Extension == "" {
-		testCase.Extension = ".pkr.hcl"
+	extension := ".pkr.hcl"
+	if err := json.Unmarshal([]byte(testCase.Template), &(map[string]interface{}{})); err == nil {
+		extension = ".json"
 	}
-	templatePath := fmt.Sprintf("./%s%s", testCase.Name, testCase.Extension)
+	templatePath := fmt.Sprintf("./%s%s", testCase.Name, extension)
 
 	// Write config hcl2 template
 	out := bytes.NewBuffer(nil)


### PR DESCRIPTION
This generic plugin acceptance test is exactly the same used for data sources but with a generic name so that can be used for all plugins. The idea is to be config language agnostic since it will write a file with the given content and extension and run `packer build` against it. 

The result would be like the acceptance tests added to https://github.com/hashicorp/packer-plugin-scaffolding/pull/6 using this structure.