### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "github.com/hashicorp/packer"
+      - dependency-name: "github.com/hashicorp/hcl/v2"
+      - dependency-name: "github.com/zclconf/go-cty"
+    ignore:
+      - dependency-name: "github.com/aws/aws-sdk-go"


### PR DESCRIPTION
Add dependabot to the repo to help keep go modules up to date. This is being done for tracking Packer and HCL pkgs. 
AWS package is being ignored because it is released every week.
