### PR TITLE
Update ugorji/go/codec to v1.2.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/pkg/sftp v0.0.0-20160118190721-e84cc8c755ca
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/stretchr/testify v1.6.1
-	github.com/ugorji/go v0.0.0-20151218193438-646ae4a518c1
+	github.com/ugorji/go/codec v1.2.4
 	github.com/zclconf/go-cty v1.7.0
 	golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9
 	golang.org/x/mobile v0.0.0-20201208152944-da85bec010a2

--- a/go.sum
+++ b/go.sum
@@ -603,6 +603,10 @@ github.com/ufilesdk-dev/ufile-gosdk v0.0.0-20190830075812-b4dbc4ef43a6 h1:FAWNiq
 github.com/ufilesdk-dev/ufile-gosdk v0.0.0-20190830075812-b4dbc4ef43a6/go.mod h1:R5FMQxkQ+QK/9Vz+jfnJP4rZIktYrRcWmuAnbOSkROI=
 github.com/ugorji/go v0.0.0-20151218193438-646ae4a518c1 h1:U6ufy3mLDgg9RYupntOvAF7xCmNNquyKaYaaVHo1Nnk=
 github.com/ugorji/go v0.0.0-20151218193438-646ae4a518c1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
+github.com/ugorji/go v1.2.4 h1:cTciPbZ/VSOzCLKclmssnfQ/jyoVyOcJ3aoJyUV1Urc=
+github.com/ugorji/go v1.2.4/go.mod h1:EuaSCk8iZMdIspsu6HXH7X2UGKw1ezO4wCfGszGmmo4=
+github.com/ugorji/go/codec v1.2.4 h1:C5VurWRRCKjuENsbM6GYVw8W++WVW9rSxoACKIvxzz8=
+github.com/ugorji/go/codec v1.2.4/go.mod h1:bWBu1+kIRWcF8uMklKaJrR6fTWQOwAlrIzX22pHwryA=
 github.com/ulikunitz/xz v0.5.5 h1:pFrO0lVpTBXLpYw+pnLj6TbvHuyjXMfjGeCwSqCVwok=
 github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -44,8 +44,7 @@ func newClientWithMux(mux *muxBroker, streamId uint32) (*Client, error) {
 	}
 
 	h := &codec.MsgpackHandle{
-		RawToString: true,
-		WriteExt:    true,
+		WriteExt: true,
 	}
 	clientCodec := codec.GoRpc.ClientCodec(clientConn, h)
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -153,8 +153,7 @@ func (s *PluginServer) Serve() {
 	defer stream.Close()
 
 	h := &codec.MsgpackHandle{
-		RawToString: true,
-		WriteExt:    true,
+		WriteExt: true,
 	}
 	rpcCodec := codec.GoRpc.ServerCodec(stream, h)
 	s.server.ServeCodec(rpcCodec)


### PR DESCRIPTION
This is a continuation of hashicorp/packer#10146 that was submitted before the rpc code was moved from packer to packer-plugin-sdk.

When running Packer built with modern[0] version of ugorji using a plugin built from source and therefore with the 2015 version currently pinned in Packer's go.mod, I hit ugorji/go#269 when my plugin tries to [pipe into a remote "cat > '%s'"](https://github.com/angdraug/packer-builder-nspawn-debootstrap/blob/master/builder/communicator.go#L33):

>  Build 'base-20201021-5f90bdf5-490e-582b-fb1d-b5d4315f5eaa' errored after 25 seconds 772 milliseconds: msgpack decode error [pos 274]: invalid length of bytes for decoding time - expecting 4 or 8 or 12, got 15

[0] As in, newer than ugorji/go@5a66da2 from 2017, e.g. Packer as packaged in Debian.

The same pipe works fine when either running Packer built from source (with the same pin to old ugorji), or forcing the plugin to build with the modern ugorji:

```
replace github.com/hashicorp/packer => github.com/angdraug/packer v1.6.4-ugorji-go-v1.1.13
```

Bringing ugorji in Packer to the current version will leap over this and other incompatibilities that have built up in ugorji over the years, will make custom plugins work out of the box with the Debian build of Packer, and will allow plugin writers to use modules that depend on newer versions of ugorji.