### PR TITLE
[wip] Add custom MapOfInterfaceToMapOfCTY decoder

### DIFF
--- a/hcl2helper/values_test.go
+++ b/hcl2helper/values_test.go
@@ -109,6 +109,11 @@ func TestHCL2ValueFromConfigValue(t *testing.T) {
 				cty.StringVal("c"),
 			}),
 		},
+		{
+			Name:  "Empty SliceString",
+			Input: []string{},
+			Want:  cty.ListValEmpty(cty.String),
+		},
 	}
 
 	for _, test := range tests {

--- a/template/config/decode.go
+++ b/template/config/decode.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl/v2/hcldec"
+	"github.com/hashicorp/packer-plugin-sdk/template/config/internal"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 	"github.com/mitchellh/mapstructure"
 	"github.com/ryanuber/go-glob"
@@ -42,7 +43,7 @@ type DecodeOpts struct {
 var DefaultDecodeHookFuncs = []mapstructure.DecodeHookFunc{
 	uint8ToStringHook,
 	stringToTrilean,
-	mapOfCTYToMapOfInterface,
+	internal.MapOfInterfaceToMapOfCTY,
 	mapstructure.StringToSliceHookFunc(","),
 	mapstructure.StringToTimeDurationHookFunc(),
 }
@@ -325,30 +326,6 @@ func stringToTrilean(f reflect.Type, t reflect.Type, v interface{}) (interface{}
 			}
 		}
 
-	}
-	return v, nil
-}
-
-// HCL is not able to decode map[string]interface{}, we must use a map[string]cty.Value instead.
-// mapOfCTYToMapOfInterface will transform the map[string]interface{} decoded from a config
-// to the expected map[string]cty.Value.
-func mapOfCTYToMapOfInterface(f reflect.Type, t reflect.Type, v interface{}) (interface{}, error) {
-	if t == reflect.TypeOf(map[string]cty.Value{}) {
-		to := map[string]cty.Value{}
-		if from, ok := v.(map[string]interface{}); ok {
-			for key, val := range from {
-				impliedValType, err := gocty.ImpliedType(val)
-				if err != nil {
-					return val, err
-				}
-				value, err := gocty.ToCtyValue(val, impliedValType)
-				if err != nil {
-					return val, err
-				}
-				to[key] = value
-			}
-		}
-		return to, nil
 	}
 	return v, nil
 }

--- a/template/config/decode.go
+++ b/template/config/decode.go
@@ -329,6 +329,9 @@ func stringToTrilean(f reflect.Type, t reflect.Type, v interface{}) (interface{}
 	return v, nil
 }
 
+// HCL is not able to decode map[string]interface{}, we must use a map[string]cty.Value instead.
+// mapOfCTYToMapOfInterface will transform the map[string]interface{} decoded from a config
+// to the expected map[string]cty.Value.
 func mapOfCTYToMapOfInterface(f reflect.Type, t reflect.Type, v interface{}) (interface{}, error) {
 	if t == reflect.TypeOf(map[string]cty.Value{}) {
 		to := map[string]cty.Value{}

--- a/template/config/decode_test.go
+++ b/template/config/decode_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/zclconf/go-cty/cty"
 	"reflect"
 	"strings"
 	"testing"
@@ -11,10 +12,11 @@ import (
 
 func TestDecode(t *testing.T) {
 	type Target struct {
-		Name    string
-		Address string
-		Time    time.Duration
-		Trilean Trilean
+		Name        string
+		Address     string
+		Time        time.Duration
+		Trilean     Trilean
+		MapCtyValue map[string]cty.Value
 	}
 
 	cases := map[string]struct {
@@ -117,6 +119,29 @@ func TestDecode(t *testing.T) {
 			},
 			&Target{
 				Name: "foo",
+			},
+			nil,
+		},
+		"map of cty.Value": {
+			[]interface{}{
+				map[string]interface{}{
+					"mapCtyValue": map[string]interface{}{
+						"foo": "bar",
+						"nested": map[string]interface{}{
+							"nested_foo": "nested_bar",
+						},
+						"number": 1,
+					},
+				},
+			},
+			&Target{
+				MapCtyValue: map[string]cty.Value{
+					"foo": cty.StringVal("bar"),
+					"nested": cty.MapVal(map[string]cty.Value{
+						"nested_foo": cty.StringVal("nested_bar"),
+					}),
+					"number": cty.NumberIntVal(1),
+				},
 			},
 			nil,
 		},

--- a/template/config/decode_test.go
+++ b/template/config/decode_test.go
@@ -137,7 +137,7 @@ func TestDecode(t *testing.T) {
 			&Target{
 				MapCtyValue: map[string]cty.Value{
 					"foo": cty.StringVal("bar"),
-					"nested": cty.MapVal(map[string]cty.Value{
+					"nested": cty.ObjectVal(map[string]cty.Value{
 						"nested_foo": cty.StringVal("nested_bar"),
 					}),
 					"number": cty.NumberIntVal(1),

--- a/template/config/internal/decoder.go
+++ b/template/config/internal/decoder.go
@@ -55,10 +55,7 @@ func InterfaceToCTY(v interface{}) cty.Value {
 		for k, ev := range tv {
 			vals[k] = InterfaceToCTY(ev)
 		}
-		if len(vals) == 0 {
-			return cty.MapValEmpty(cty.String)
-		}
-		return cty.MapVal(vals)
+		return cty.ObjectVal(vals)
 	}
 
 	impliedValType, err := gocty.ImpliedType(v)

--- a/template/config/internal/decoder.go
+++ b/template/config/internal/decoder.go
@@ -26,7 +26,7 @@ func MapOfInterfaceToMapOfCTY(f reflect.Type, t reflect.Type, v interface{}) (in
 }
 
 // InterfaceToCTY is a similar to hcl2helper.HCL2ValueFromConfigValue
-// but it contains an extra decoding case and is placed here to avoid cyclic dependency.
+// and is placed here to avoid cyclic dependency.
 // It takes a value and turns it into a cty.Value for the config decoder.
 // This for internal usage only, used by the decoder above.
 func InterfaceToCTY(v interface{}) cty.Value {
@@ -55,14 +55,10 @@ func InterfaceToCTY(v interface{}) cty.Value {
 		for k, ev := range tv {
 			vals[k] = InterfaceToCTY(ev)
 		}
-		return cty.ObjectVal(vals)
-	case map[interface{}]interface{}:
-		vals := []cty.Value{}
-		for k, ev := range tv {
-			vals = append(vals, InterfaceToCTY(k))
-			vals = append(vals, InterfaceToCTY(ev))
+		if len(vals) == 0 {
+			return cty.MapValEmpty(cty.String)
 		}
-		return cty.TupleVal(vals)
+		return cty.MapVal(vals)
 	}
 
 	impliedValType, err := gocty.ImpliedType(v)

--- a/template/config/internal/decoder.go
+++ b/template/config/internal/decoder.go
@@ -1,0 +1,81 @@
+package internal
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/gocty"
+)
+
+// HCL is not able to decode map[string]interface{}, we must use a map[string]cty.Value instead.
+// ref: https://github.com/hashicorp/hcl/issues/291#issuecomment-496347585
+// MapOfInterfaceToMapOfCTY will transform the map[string]interface{} decoded from a config
+// to the expected map[string]cty.Value.
+func MapOfInterfaceToMapOfCTY(f reflect.Type, t reflect.Type, v interface{}) (interface{}, error) {
+	if t == reflect.TypeOf(map[string]cty.Value{}) {
+		to := map[string]cty.Value{}
+		if from, ok := v.(map[string]interface{}); ok {
+			for key, val := range from {
+				to[key] = InterfaceToCTY(val)
+			}
+		}
+		return to, nil
+	}
+	return v, nil
+}
+
+// InterfaceToCTY is a similar to hcl2helper.HCL2ValueFromConfigValue
+// but it contains an extra decoding case and is placed here to avoid cyclic dependency.
+// It takes a value and turns it into a cty.Value for the config decoder.
+// This for internal usage only, used by the decoder above.
+func InterfaceToCTY(v interface{}) cty.Value {
+	if v == nil {
+		return cty.NullVal(cty.DynamicPseudoType)
+	}
+
+	switch tv := v.(type) {
+	case []interface{}:
+		vals := make([]cty.Value, len(tv))
+		for i, ev := range tv {
+			vals[i] = InterfaceToCTY(ev)
+		}
+		return cty.TupleVal(vals)
+	case []string:
+		vals := make([]cty.Value, len(tv))
+		for i, ev := range tv {
+			vals[i] = cty.StringVal(ev)
+		}
+		if len(vals) == 0 {
+			return cty.ListValEmpty(cty.String)
+		}
+		return cty.ListVal(vals)
+	case map[string]interface{}:
+		vals := map[string]cty.Value{}
+		for k, ev := range tv {
+			vals[k] = InterfaceToCTY(ev)
+		}
+		return cty.ObjectVal(vals)
+	case map[interface{}]interface{}:
+		vals := []cty.Value{}
+		for k, ev := range tv {
+			vals = append(vals, InterfaceToCTY(k))
+			vals = append(vals, InterfaceToCTY(ev))
+		}
+		return cty.TupleVal(vals)
+	}
+
+	impliedValType, err := gocty.ImpliedType(v)
+	if err != nil {
+		// HCL/HIL should never generate anything that isn't caught by
+		// the above, so if we get here something has gone very wrong.
+		panic(fmt.Errorf("can't convert %#v to cty.Value: %s", v, err.Error()))
+	}
+	value, err := gocty.ToCtyValue(v, impliedValType)
+	if err != nil {
+		// HCL/HIL should never generate anything that isn't caught by
+		// the above, so if we get here something has gone very wrong.
+		panic(fmt.Errorf("can't convert %#v to cty.Value %s", v, err.Error()))
+	}
+	return value
+}

--- a/template/config/internal/decoder_test.go
+++ b/template/config/internal/decoder_test.go
@@ -24,7 +24,7 @@ func TestMapOfInterfaceToMapOfCTY(t *testing.T) {
 	}
 
 	expectedOutput := map[string]cty.Value{
-		"foo": cty.MapVal(map[string]cty.Value{
+		"foo": cty.ObjectVal(map[string]cty.Value{
 			"bar": cty.StringVal("baz"),
 		}),
 		"bar": cty.TupleVal([]cty.Value{
@@ -125,6 +125,11 @@ func TestInterfaceToCTY(t *testing.T) {
 			}),
 		},
 		{
+			Name:  "empty map[string]interface{}",
+			Input: map[string]interface{}{},
+			Want:  cty.EmptyObjectVal,
+		},
+		{
 			Name: "[]interface{} as tuple",
 			Input: []interface{}{
 				"foo",
@@ -134,6 +139,11 @@ func TestInterfaceToCTY(t *testing.T) {
 				cty.StringVal("foo"),
 				cty.True,
 			}),
+		},
+		{
+			Name:  "empty []interface{} as empty tuple",
+			Input: []interface{}{},
+			Want:  cty.EmptyTupleVal,
 		},
 		{
 			Name:  "nil",
@@ -157,24 +167,6 @@ func TestInterfaceToCTY(t *testing.T) {
 			Name:  "Empty SliceString",
 			Input: []string{},
 			Want:  cty.ListValEmpty(cty.String),
-		},
-		{
-			Name: "map[interface{}]interface{}",
-			Input: map[interface{}]interface{}{
-				"name": "Ermintrude",
-				1:      2,
-			},
-			Want: cty.TupleVal([]cty.Value{
-				cty.StringVal("name"),
-				cty.StringVal("Ermintrude"),
-				cty.NumberIntVal(1),
-				cty.NumberIntVal(2),
-			}),
-		},
-		{
-			Name:  "empty map[interface{}]interface{}",
-			Input: map[interface{}]interface{}{},
-			Want:  cty.EmptyTupleVal,
 		},
 	}
 

--- a/template/config/internal/decoder_test.go
+++ b/template/config/internal/decoder_test.go
@@ -1,0 +1,199 @@
+package internal
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestMapOfInterfaceToMapOfCTY(t *testing.T) {
+	input := map[string]interface{}{
+		"foo": map[interface{}]interface{}{
+			"bar": []uint8("baz"),
+		},
+		"bar": []interface{}{
+			"foo",
+
+			map[interface{}]interface{}{
+				"bar": "baz",
+			},
+		},
+		"bFalse": false,
+		"bTrue":  true,
+		"bNil":   nil,
+		"bStr":   []uint8("bar"),
+		"bInt":   1,
+		"bFloat": 4.5,
+	}
+
+	expectedOutput := map[string]cty.Value{
+		"foo": cty.TupleVal([]cty.Value{
+			cty.StringVal("bar"),
+			cty.ListVal([]cty.Value{cty.NumberIntVal(98), cty.NumberIntVal(97), cty.NumberIntVal(122)}),
+		}),
+		"bar": cty.TupleVal([]cty.Value{
+			cty.StringVal("foo"),
+			cty.TupleVal([]cty.Value{
+				cty.StringVal("bar"),
+				cty.StringVal("baz"),
+			}),
+		}),
+		"bFalse": cty.False,
+		"bTrue":  cty.True,
+		"bNil":   cty.NilVal,
+		"bStr":   cty.ListVal([]cty.Value{cty.NumberIntVal(98), cty.NumberIntVal(97), cty.NumberIntVal(114)}),
+		"bInt":   cty.NumberIntVal(1),
+		"bFloat": cty.NumberFloatVal(4.5),
+	}
+
+	output, err := MapOfInterfaceToMapOfCTY(reflect.TypeOf(input), reflect.TypeOf(expectedOutput), input)
+	if err != nil {
+		t.Fatalf("Unexpected error %s", err.Error())
+	}
+
+	if _, ok := output.(map[string]cty.Value); !ok {
+		t.Fatalf("expecting output to be of type map[string]cty.Value")
+	}
+
+	outCty := output.(map[string]cty.Value)
+	for k, v := range expectedOutput {
+		outVal, ok := outCty[k]
+		if !ok {
+			t.Fatalf("expected key %s not found", k)
+		}
+		equals := v.Equals(outVal)
+		if equals.False() {
+			t.Fatalf("Unexpected val for key: \nkey: %s \nval: %s\nexpecting: %s", k, outVal.GoString(), v.GoString())
+		}
+	}
+}
+
+func TestInterfaceToCTY(t *testing.T) {
+	tests := []struct {
+		Name  string
+		Input interface{}
+		Want  cty.Value
+	}{
+		{
+			Name:  "bool true",
+			Input: true,
+			Want:  cty.True,
+		},
+		{
+			Name:  "bool false",
+			Input: false,
+			Want:  cty.False,
+		},
+		{
+			Name:  "int",
+			Input: int(12),
+			Want:  cty.NumberIntVal(12),
+		},
+		{
+			Name:  "float64",
+			Input: float64(12.5),
+			Want:  cty.NumberFloatVal(12.5),
+		},
+		{
+			Name:  "string",
+			Input: "hello world",
+			Want:  cty.StringVal("hello world"),
+		},
+		{
+			Name: "nested map[string]interface{}",
+			Input: map[string]interface{}{
+				"name": "Ermintrude",
+				"age":  int(19),
+				"address": map[string]interface{}{
+					"street": []interface{}{"421 Shoreham Loop"},
+					"city":   "Fridgewater",
+					"state":  "MA",
+					"zip":    "91037",
+				},
+			},
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"name": cty.StringVal("Ermintrude"),
+				"age":  cty.NumberIntVal(19),
+				"address": cty.ObjectVal(map[string]cty.Value{
+					"street": cty.TupleVal([]cty.Value{cty.StringVal("421 Shoreham Loop")}),
+					"city":   cty.StringVal("Fridgewater"),
+					"state":  cty.StringVal("MA"),
+					"zip":    cty.StringVal("91037"),
+				}),
+			}),
+		},
+		{
+			Name: "simple map[string]interface{}",
+			Input: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			Want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.StringVal("bar"),
+				"bar": cty.StringVal("baz"),
+			}),
+		},
+		{
+			Name: "[]interface{} as tuple",
+			Input: []interface{}{
+				"foo",
+				true,
+			},
+			Want: cty.TupleVal([]cty.Value{
+				cty.StringVal("foo"),
+				cty.True,
+			}),
+		},
+		{
+			Name:  "nil",
+			Input: nil,
+			Want:  cty.NullVal(cty.DynamicPseudoType),
+		},
+		{
+			Name: "SliceString",
+			Input: []string{
+				"a",
+				"b",
+				"c",
+			},
+			Want: cty.ListVal([]cty.Value{
+				cty.StringVal("a"),
+				cty.StringVal("b"),
+				cty.StringVal("c"),
+			}),
+		},
+		{
+			Name:  "Empty SliceString",
+			Input: []string{},
+			Want:  cty.ListValEmpty(cty.String),
+		},
+		{
+			Name: "map[interface{}]interface{}",
+			Input: map[interface{}]interface{}{
+				"name": "Ermintrude",
+				1:      2,
+			},
+			Want: cty.TupleVal([]cty.Value{
+				cty.StringVal("name"),
+				cty.StringVal("Ermintrude"),
+				cty.NumberIntVal(1),
+				cty.NumberIntVal(2),
+			}),
+		},
+		{
+			Name:  "empty map[interface{}]interface{}",
+			Input: map[interface{}]interface{}{},
+			Want:  cty.EmptyTupleVal,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			got := InterfaceToCTY(test.Input)
+			if !reflect.DeepEqual(got, test.Want) {
+				t.Errorf("wrong result\ninput: %#v\ngot:   %#v\nwant:  %#v", test.Input, got, test.Want)
+			}
+		})
+	}
+}

--- a/template/config/internal/decoder_test.go
+++ b/template/config/internal/decoder_test.go
@@ -9,40 +9,30 @@ import (
 
 func TestMapOfInterfaceToMapOfCTY(t *testing.T) {
 	input := map[string]interface{}{
-		"foo": map[interface{}]interface{}{
-			"bar": []uint8("baz"),
+		"foo": map[string]interface{}{
+			"bar": "baz",
 		},
 		"bar": []interface{}{
 			"foo",
-
-			map[interface{}]interface{}{
-				"bar": "baz",
-			},
 		},
 		"bFalse": false,
 		"bTrue":  true,
 		"bNil":   nil,
-		"bStr":   []uint8("bar"),
+		"bStr":   "bar",
 		"bInt":   1,
 		"bFloat": 4.5,
 	}
 
 	expectedOutput := map[string]cty.Value{
-		"foo": cty.TupleVal([]cty.Value{
-			cty.StringVal("bar"),
-			cty.ListVal([]cty.Value{cty.NumberIntVal(98), cty.NumberIntVal(97), cty.NumberIntVal(122)}),
+		"foo": cty.MapVal(map[string]cty.Value{
+			"bar": cty.StringVal("baz"),
 		}),
 		"bar": cty.TupleVal([]cty.Value{
 			cty.StringVal("foo"),
-			cty.TupleVal([]cty.Value{
-				cty.StringVal("bar"),
-				cty.StringVal("baz"),
-			}),
 		}),
 		"bFalse": cty.False,
 		"bTrue":  cty.True,
-		"bNil":   cty.NilVal,
-		"bStr":   cty.ListVal([]cty.Value{cty.NumberIntVal(98), cty.NumberIntVal(97), cty.NumberIntVal(114)}),
+		"bStr":   cty.StringVal("bar"),
 		"bInt":   cty.NumberIntVal(1),
 		"bFloat": cty.NumberFloatVal(4.5),
 	}


### PR DESCRIPTION
Changes needed to https://github.com/hashicorp/packer/pull/10655
This will allow config as `map[string]cty.Value` which is the valid option for when `map[string]interface{}` is needed.