### PR TITLE
Fix shift break code order for PC XT and VNC drivers

### DIFF
--- a/bootcommand/pc_xt_driver.go
+++ b/bootcommand/pc_xt_driver.go
@@ -48,7 +48,7 @@ func NewPCXTDriver(send SendCodeFunc, chunkSize int, interval time.Duration) *pc
 		keyInterval = interval
 	}
 	// Scancodes reference: https://www.win.tue.nl/~aeb/linux/kbd/scancodes-1.html
-	//						https://www.win.tue.nl/~aeb/linux/kbd/scancodes-10.html
+	//                      https://www.win.tue.nl/~aeb/linux/kbd/scancodes-10.html
 	//
 	// Scancodes are recorded here in pairs. The first entry represents
 	// the key press and the second entry represents the key release and is
@@ -156,10 +156,10 @@ func (d *pcXTDriver) SendKey(key rune, action KeyAction) error {
 
 	if action&(KeyOff|KeyPress) != 0 {
 		scInt := d.scancodeMap[key] + 0x80
+		sc = append(sc, fmt.Sprintf("%02x", scInt))
 		if keyShift {
 			sc = append(sc, "aa")
 		}
-		sc = append(sc, fmt.Sprintf("%02x", scInt))
 	}
 
 	log.Printf("Sending char '%c', code '%s', shift %v",

--- a/bootcommand/pc_xt_driver_test.go
+++ b/bootcommand/pc_xt_driver_test.go
@@ -104,6 +104,22 @@ func Test_pcxtSpecial(t *testing.T) {
 	assert.Equal(t, expected, codes)
 }
 
+func Test_pcxtShift(t *testing.T) {
+	in := "AbC"
+	expected := []string{"2a", "1e", "9e", "aa", "30", "b0", "2a", "2e", "ae", "aa"}
+	var codes []string
+	sendCodes := func(c []string) error {
+		codes = c
+		return nil
+	}
+	d := NewPCXTDriver(sendCodes, -1, time.Duration(0))
+	seq, err := GenerateExpressionSequence(in)
+	assert.NoError(t, err)
+	err = seq.Do(context.Background(), d)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, codes)
+}
+
 func Test_flushes(t *testing.T) {
 	in := "abc123<wait>098"
 	expected := [][]string{

--- a/bootcommand/vnc_driver.go
+++ b/bootcommand/vnc_driver.go
@@ -111,10 +111,10 @@ func (d *vncDriver) SendKey(key rune, action KeyAction) error {
 		}
 		d.keyEvent(keyCode, true)
 	case KeyOff:
+		d.keyEvent(keyCode, false)
 		if keyShift {
 			d.keyEvent(KeyLeftShift, false)
 		}
-		d.keyEvent(keyCode, false)
 	case KeyPress:
 		if keyShift {
 			d.keyEvent(KeyLeftShift, true)

--- a/bootcommand/vnc_driver_test.go
+++ b/bootcommand/vnc_driver_test.go
@@ -39,6 +39,46 @@ func Test_vncSpecialLookup(t *testing.T) {
 	assert.Equal(t, expected, s.e)
 }
 
+func Test_vncShiftSequence(t *testing.T) {
+	in := "AbC"
+	expected := []event{
+		{0xFFE1, true},
+		{0x041, true},
+		{0x041, false},
+		{0xFFE1, false},
+		{0x062, true},
+		{0x062, false},
+		{0xFFE1, true},
+		{0x043, true},
+		{0x043, false},
+		{0xFFE1, false},
+	}
+	s := &sender{}
+	d := NewVNCDriver(s, time.Duration(0))
+	seq, err := GenerateExpressionSequence(in)
+	assert.NoError(t, err)
+	err = seq.Do(context.Background(), d)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, s.e)
+}
+
+func Test_vncShiftSingle(t *testing.T) {
+	in := "<Aon><Aoff>"
+	expected := []event{
+		{0xFFE1, true},
+		{0x041, true},
+		{0x041, false},
+		{0xFFE1, false},
+	}
+	s := &sender{}
+	d := NewVNCDriver(s, time.Duration(0))
+	seq, err := GenerateExpressionSequence(in)
+	assert.NoError(t, err)
+	err = seq.Do(context.Background(), d)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, s.e)
+}
+
 func Test_vncIntervalNotGiven(t *testing.T) {
 	s := &sender{}
 	d := NewVNCDriver(s, time.Duration(0))


### PR DESCRIPTION
When typing an upper case character, the scancode for the base key is wrapped with the make/break codes for "Left Shift" (`2a/aa`). For example, typing the letter "N" (`31/f0`) would use the scancode `2a 31 f0 aa`.

This PR fixes an issue with the last two scancodes when typing a character that requires shift. Currently, the last two scancodes are inverted, e.g. `2a 31 aa f0`. This results in Left Shift being released _prior_ to the base key's break code.

I noticed this issue while trying to debug the `prltype.py` script used for typing the boot command in the Parallels builder with macOS VMs (another PR to come). Problems caused by this early `aa` scancode seem more prominent on macOS guests—it may be due to worse guest VM performance. For example, I would often see a colon in the boot command typed as `:;`—the base key was still being held as shift was released, resulting in the upper case character followed by the base character.

Note: I am a newbie to Go but gave this my best shot and I welcome any feedback. 