### PR TITLE
Update GPG usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,9 @@ steps:
     run:
       name: import base64 GPG key and prime passphrase
       command: |
-        echo -e "${GPG_KEY}" | base64 -di | gpg --import --batch
+        echo -e "${RELEASES_GPG_PRIV_KEY_B64}" | base64 -di | gpg --import --batch
         echo "hello world" > temp.txt
-        gpg --detach-sig --yes -v --output=/dev/null --pinentry-mode loopback --passphrase "${GPG_PASSPHRASE}" temp.txt
+        gpg --detach-sig --yes -v --output=/dev/null --pinentry-mode loopback --passphrase "${RELEASES_GPG_PASSPHRASE}" temp.txt
         rm temp.txt
 
 commands:
@@ -141,6 +141,9 @@ workflows:
                 - main
           type: approval
       - release-sdk:
+          context:
+            - releases-gpg-private-signing-key
+            - releases-gpg-public-signing-key
           filters:
             branches:
               only:

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -80,7 +80,7 @@ function commitChanges {
   modifyVersionFiles
   git add version/version.go
 
-	if [ "$CI" == true ]; then
+  if [ "$CI" == true ]; then
     git commit --gpg-sign="${RELEASES_GPG_KEY_ID}" -m "v${TARGET_VERSION} [skip ci]"
     git tag -a -m "v${TARGET_VERSION}" -s -u "${RELEASES_GPG_KEY_ID}" "v${TARGET_VERSION}"
     git push origin "${CIRCLE_BRANCH}"

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -15,8 +15,8 @@ function pleaseUseGNUsed {
 }
 
 function gpgKeyCheck {
-  if [ -z "${GPG_KEY_ID}" ]; then
-    printf "A valid GPG_KEY_ID is needed to sign the release...exiting\n"
+  if [ -z "${RELEASES_GPG_KEY_ID}" ]; then
+    printf "A valid RELEASES_GPG_KEY_ID is needed to sign the release...exiting\n"
 		exit 1
   fi
 }
@@ -81,8 +81,8 @@ function commitChanges {
   git add version/version.go
 
 	if [ "$CI" == true ]; then
-    git commit --gpg-sign="${GPG_KEY_ID}" -m "v${TARGET_VERSION} [skip ci]"
-    git tag -a -m "v${TARGET_VERSION}" -s -u "${GPG_KEY_ID}" "v${TARGET_VERSION}"
+    git commit --gpg-sign="${RELEASES_GPG_KEY_ID}" -m "v${TARGET_VERSION} [skip ci]"
+    git tag -a -m "v${TARGET_VERSION}" -s -u "${RELEASES_GPG_KEY_ID}" "v${TARGET_VERSION}"
     git push origin "${CIRCLE_BRANCH}"
   else
     printf "Skipping GPG signature on non CI releases...\n"


### PR DESCRIPTION
As part of rotating the GPG key used for signing products, we are also moving the GPG bits into a dedicated CircleCI context.  This PR renames the GPG env vars to match those from the new context and applies the context to the job that uses the key.

This was tested locally by modifying the `release.sh` script to not push commits, setting the environment variables to match my local keyring, running the script, and inspecting the produced commit with `git log -n 1 --show-signature`