### PR TITLE
CDConfig: Add cd_content for file templating

### DIFF
--- a/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/multistep/commonsteps/CDConfig-not-required.mdx
+++ b/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/multistep/commonsteps/CDConfig-not-required.mdx
@@ -44,6 +44,22 @@
     * hdiutil (normally found in macOS)
     * oscdimg (normally found in Windows as part of the Windows ADK)
 
+- `cd_content` (map[string]string) - Key/Values to add to the CD. The keys represent the paths, and the values
+  contents. It can be used alongside `cd_files`, which is useful to add large
+  files without loading them into memory. If any paths are specified by both,
+  the contents in `cd_content` will take precedence.
+  
+  Usage example (HCL):
+  
+  ```hcl
+  cd_files = ["vendor-data"]
+  cd_content = {
+    "meta-data" = jsonencode(local.instance_data)
+    "user-data" = templatefile("user-data", { packages = ["nginx"] })
+  }
+  cd_label = "cidata"
+  ```
+
 - `cd_label` (string) - CD Label
 
 <!-- End of code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; -->

--- a/multistep/commonsteps/extra_iso_config.go
+++ b/multistep/commonsteps/extra_iso_config.go
@@ -65,7 +65,23 @@ type CDConfig struct {
 	//   * hdiutil (normally found in macOS)
 	//   * oscdimg (normally found in Windows as part of the Windows ADK)
 	CDFiles []string `mapstructure:"cd_files"`
-	CDLabel string   `mapstructure:"cd_label"`
+	// Key/Values to add to the CD. The keys represent the paths, and the values
+	// contents. It can be used alongside `cd_files`, which is useful to add large
+	// files without loading them into memory. If any paths are specified by both,
+	// the contents in `cd_content` will take precedence.
+	//
+	// Usage example (HCL):
+	//
+	// ```hcl
+	// cd_files = ["vendor-data"]
+	// cd_content = {
+	//   "meta-data" = jsonencode(local.instance_data)
+	//   "user-data" = templatefile("user-data", { packages = ["nginx"] })
+	// }
+	// cd_label = "cidata"
+	// ```
+	CDContent map[string]string `mapstructure:"cd_content"`
+	CDLabel   string            `mapstructure:"cd_label"`
 }
 
 func (c *CDConfig) Prepare(ctx *interpolate.Context) []error {

--- a/multistep/commonsteps/step_create_cdrom.go
+++ b/multistep/commonsteps/step_create_cdrom.go
@@ -304,9 +304,8 @@ func (s *StepCreateCD) AddFile(dst, src string) error {
 }
 
 func (s *StepCreateCD) AddContent(dst, path, content string) error {
-	// Clean the path so we can join it without path traversal issues. Converting it to an
-	// absolute path removes any leading ".."
-	dstPath := filepath.Join(dst, filepath.Clean(string(filepath.Separator)+path))
+	// Join Cleans the path so we can join it without path traversal issues.
+	dstPath := filepath.Join(dst, path)
 	dstDir := filepath.Dir(dstPath)
 	err := os.MkdirAll(dstDir, 0777)
 	if err != nil {


### PR DESCRIPTION
Implement `cd_content` from hashicorp/packer#10859, allowing file templating similar to `http_content`.

There currently aren't any tests for this feature. I'd like to first make the `cd_files` tests more robust (at the moment they only test that there are the expected number of keys in `filesAdded`), and then add tests for `cd_content` (including when used alongside `cd_files`).