### PR TITLE
StepCreateCD: Clean up temporary directory and add more robust tests

### DIFF
--- a/multistep/commonsteps/step_create_cdrom.go
+++ b/multistep/commonsteps/step_create_cdrom.go
@@ -27,7 +27,6 @@ type StepCreateCD struct {
 
 	CDPath string
 
-	filesAdded map[string]bool
 	rootFolder string
 }
 
@@ -45,9 +44,6 @@ func (s *StepCreateCD) Run(ctx context.Context, state multistep.StateBag) multis
 	} else {
 		log.Printf("CD label is set to %s", s.Label)
 	}
-
-	// Track what files are added. Used for testing step.
-	s.filesAdded = make(map[string]bool)
 
 	// Create a temporary file to be our CD drive
 	CDF, err := tmp.File("packer*.iso")
@@ -236,7 +232,6 @@ func (s *StepCreateCD) AddFile(dst, src string) error {
 		if err != nil {
 			return fmt.Errorf("Error copying %s to CD root", src)
 		}
-		s.filesAdded[src] = true
 		log.Printf("Wrote %d bytes to %s", nBytes, finfo.Name())
 		return err
 	}
@@ -278,7 +273,6 @@ func (s *StepCreateCD) AddFile(dst, src string) error {
 			if err != nil {
 				return fmt.Errorf("Error copying %s to CD: %s", dstPath, err)
 			}
-			s.filesAdded[dstPath] = true
 			log.Printf("Wrote %d bytes to %s", nBytes, dstPath)
 			return err
 		}

--- a/multistep/commonsteps/step_create_cdrom.go
+++ b/multistep/commonsteps/step_create_cdrom.go
@@ -28,6 +28,7 @@ type StepCreateCD struct {
 	CDPath string
 
 	filesAdded map[string]bool
+	rootFolder string
 }
 
 func (s *StepCreateCD) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -71,6 +72,7 @@ func (s *StepCreateCD) Run(ctx context.Context, state multistep.StateBag) multis
 			fmt.Errorf("Error creating temporary file for CD: %s", err))
 		return multistep.ActionHalt
 	}
+	s.rootFolder = rootFolder
 
 	for _, toAdd := range s.Files {
 		err = s.AddFile(rootFolder, toAdd)
@@ -107,6 +109,9 @@ func (s *StepCreateCD) Run(ctx context.Context, state multistep.StateBag) multis
 }
 
 func (s *StepCreateCD) Cleanup(multistep.StateBag) {
+	if s.rootFolder != "" {
+		os.RemoveAll(s.rootFolder)
+	}
 	if s.CDPath != "" {
 		log.Printf("Deleting CD disk: %s", s.CDPath)
 		os.Remove(s.CDPath)

--- a/multistep/commonsteps/step_create_cdrom_test.go
+++ b/multistep/commonsteps/step_create_cdrom_test.go
@@ -81,6 +81,9 @@ func TestStepCreateCD(t *testing.T) {
 	if _, err := os.Stat(CD_path); err == nil {
 		t.Fatalf("file found: %s for %v", CD_path, step.Files)
 	}
+	if _, err := os.Stat(step.rootFolder); err == nil {
+		t.Fatalf("folder found: %s", step.rootFolder)
+	}
 }
 
 func TestStepCreateCD_missing(t *testing.T) {
@@ -115,5 +118,11 @@ func TestStepCreateCD_missing(t *testing.T) {
 
 	if len(step.filesAdded) != expected {
 		t.Fatalf("expected %d, found %d for %v", expected, len(step.filesAdded), step.Files)
+	}
+
+	step.Cleanup(state)
+
+	if _, err := os.Stat(step.rootFolder); err == nil {
+		t.Fatalf("folder found: %s", step.rootFolder)
 	}
 }

--- a/multistep/commonsteps/step_create_cdrom_test.go
+++ b/multistep/commonsteps/step_create_cdrom_test.go
@@ -33,8 +33,11 @@ func testStepCreateCDState(t *testing.T) multistep.StateBag {
 func createFiles(t *testing.T, rootFolder string, expected map[string]string) {
 	for fname, content := range expected {
 		path := filepath.Join(rootFolder, fname)
-		os.MkdirAll(filepath.Dir(path), 0777)
-		err := ioutil.WriteFile(path, []byte(content), 0666)
+		err := os.MkdirAll(filepath.Dir(path), 0777)
+		if err != nil {
+			t.Fatalf("mkdir -p: %s", err)
+		}
+		err = ioutil.WriteFile(path, []byte(content), 0666)
 		if err != nil {
 			t.Fatalf("writing file: %s", err)
 		}

--- a/multistep/commonsteps/step_create_cdrom_test.go
+++ b/multistep/commonsteps/step_create_cdrom_test.go
@@ -42,7 +42,7 @@ func createFiles(t *testing.T, rootFolder string, expected map[string]string) {
 }
 
 func checkFiles(t *testing.T, rootFolder string, expected map[string]string) {
-	filepath.WalkDir(rootFolder, func(path string, d fs.DirEntry, err error) error {
+	err := filepath.WalkDir(rootFolder, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			t.Fatalf("walking folder: %s", err)
 		}
@@ -68,7 +68,9 @@ func checkFiles(t *testing.T, rootFolder string, expected map[string]string) {
 
 		return nil
 	})
-
+	if err != nil {
+		t.Fatalf("WalkDir: %v", err)
+	}
 	if len(expected) != 0 {
 		t.Fatalf("missing files: %v", expected)
 	}

--- a/multistep/commonsteps/step_create_cdrom_test.go
+++ b/multistep/commonsteps/step_create_cdrom_test.go
@@ -87,13 +87,17 @@ func TestStepCreateCD(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	createFiles(t, dir, map[string]string{
-		"test_cd_roms.tmp":    "",
-		"test cd files.tmp":   "",
-		"Test-Test-Test5.tmp": "",
-	})
+	expected := map[string]string{
+		"test folder/b/test1": "1",
+		"test folder/b/test2": "2",
+		"test folder 2/x":     "3",
+		"test_cd_roms.tmp":    "4",
+		"test cd files.tmp":   "5",
+		"Test-Test-Test5.tmp": "6",
+	}
 
-	files := []string{"test_cd_roms.tmp", "test cd files.tmp", "Test-Test-Test5.tmp"}
+	createFiles(t, dir, expected)
+	files := []string{"test folder", "test folder 2/", "test_cd_roms.tmp", "test cd files.tmp", "Test-Test-Test5.tmp"}
 
 	step.Files = make([]string, len(files))
 	for i, fname := range files {
@@ -115,11 +119,7 @@ func TestStepCreateCD(t *testing.T) {
 		t.Fatalf("file not found: %s for %v", CD_path, step.Files)
 	}
 
-	checkFiles(t, step.rootFolder, map[string]string{
-		"test_cd_roms.tmp":    "",
-		"test cd files.tmp":   "",
-		"Test-Test-Test5.tmp": "",
-	})
+	checkFiles(t, step.rootFolder, expected)
 
 	step.Cleanup(state)
 


### PR DESCRIPTION
This adds more robust tests that check the actual filenames and contents in the temporary directory, as well as removing the temporary directory in the step cleanup. This also tests adding folders, which wasn't previously being tested. 

The motivation for checking the content is to allow tests for #61 that test how `cd_files` and `cd_content` interact (e.g. that `cd_content` correctly takes precedence over `cd_files`).