### PR TITLE
Capitalize some parts of the output

### DIFF
--- a/communicator/step_connect.go
+++ b/communicator/step_connect.go
@@ -99,7 +99,14 @@ func (s *StepConnect) Run(ctx context.Context, state multistep.StateBag) multist
 	}
 
 	if host, err := s.Host(state); err == nil {
-		ui.Say(fmt.Sprintf("Using %s communicator to connect: %s", s.Config.Type, host))
+		switch s.Config.Type {
+		case "ssh":
+			ui.Say(fmt.Sprintf("Using SSH communicator to connect: %s", host))
+		case "winrm":
+			ui.Say(fmt.Sprintf("Using WinRM communicator to connect: %s", host))
+		default:
+			ui.Say(fmt.Sprintf("Using %s communicator to connect: %s", s.Config.Type, host))
+		}
 	} else {
 		log.Printf("[DEBUG] Unable to get address during connection step: %s", err)
 	}

--- a/communicator/step_ssh_keygen.go
+++ b/communicator/step_ssh_keygen.go
@@ -50,7 +50,7 @@ func (s *StepSSHKeyGen) Run(ctx context.Context, state multistep.StateBag) multi
 	ui.Say(fmt.Sprintf("Creating temporary %s SSH key for instance...", strings.ToUpper(a.String())))
 	pair, err := sshkey.GeneratePair(a, nil, s.SSHTemporaryKeyPairBits)
 	if err != nil {
-		err := fmt.Errorf("Error creating temporary ssh key: %s", err)
+		err := fmt.Errorf("Error creating temporary SSH key: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/communicator/step_ssh_keygen.go
+++ b/communicator/step_ssh_keygen.go
@@ -3,6 +3,7 @@ package communicator
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/packer-plugin-sdk/communicator/sshkey"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
@@ -46,7 +47,7 @@ func (s *StepSSHKeyGen) Run(ctx context.Context, state multistep.StateBag) multi
 		return multistep.ActionHalt
 	}
 
-	ui.Say(fmt.Sprintf("Creating temporary %s SSH key for instance...", a.String()))
+	ui.Say(fmt.Sprintf("Creating temporary %s SSH key for instance...", strings.ToUpper(a.String())))
 	pair, err := sshkey.GeneratePair(a, nil, s.SSHTemporaryKeyPairBits)
 	if err != nil {
 		err := fmt.Errorf("Error creating temporary ssh key: %s", err)


### PR DESCRIPTION
👋 Hello! I noticed some parts of the Packer build output that seemed inconsistent or used a weird capitalization. For example: "ssh" instead of "SSH", or "rsa" instead of "RSA". This PR introduces some capitalization changes to the user-facing CLI output to fix those cases.

These capitalizations are arguably really not _necessary_. Maybe this could even break assumptions for users that would want to parse Packer build output? Not totally sure. But, I figured I'd open a PR to get feedback. 😄 