### PR TITLE
Updating comments for cache and config directories to be accurate

### DIFF
--- a/packer/cache.go
+++ b/packer/cache.go
@@ -10,7 +10,6 @@ import (
 // When the directory is not absolute, CachePath will try to make a
 // a cache depending on the operating system.
 //
-// TODO: Update this with better examples
 // NOTE: cache directory will change depending on operating system dependent
 // For Windows:
 //   PACKER_CACHE_DIR=""            CacheDir() => "./packer_cache/
@@ -18,10 +17,13 @@ import (
 //   PACKER_CACHE_DIR="bar"         CacheDir("foo") => "./bar/foo
 //   PACKER_CACHE_DIR="/home/there" CacheDir("foo", "bar") => "/home/there/foo/bar
 // For Unix:
-//   PACKER_CACHE_DIR="",            XDG_CONFIG_HOME="", Default_config CacheDir() => "$HOME/cache/packer"
-//   PACKER_CACHE_DIR="",            XDG_CONFIG_HOME="", Default_config CacheDir("foo") => "$HOME/cache/packer/foo"
-//   PACKER_CACHE_DIR="bar",         XDG_CONFIG_HOME="", Default_config CacheDir("foo") => "./bar/foo
-//   PACKER_CACHE_DIR="/home/there", XDG_CONFIG_HOME="", Default_config CacheDir("foo", "bar") => "/home/there/foo/bar
+// NOTE: PACKER_CACHE_DIR will be used over XDG_CACHE_HOME environment variable
+//   PACKER_CACHE_DIR="",            XDG_CACHE_HOME="",						 CacheDir() => "$HOME/cache/packer"
+//   PACKER_CACHE_DIR="",            XDG_CACHE_HOME="", 					 CacheDir("foo") => "$HOME/cache/packer/foo"
+//   PACKER_CACHE_DIR="bar",         XDG_CACHE_HOME="", 					 CacheDir("foo") => "./bar/foo"
+//   PACKER_CACHE_DIR="/home/there", XDG_CACHE_HOME="", 					 CacheDir("foo", "bar") => "/home/there/foo/bar"
+//   PACKER_CACHE_DIR="",            XDG_CACHE_HOME="/home/there", CacheDir("foo", "bar") => "/home/there/foo/bar"
+//   PACKER_CACHE_DIR="/foo",        XDG_CACHE_HOME="/bar",        CacheDir("a", "b") => "/foo/a/b"
 func CachePath(paths ...string) (path string, err error) {
 	defer func() {
 		// create the dir based on return path if it doesn't exist

--- a/pathing/config_file.go
+++ b/pathing/config_file.go
@@ -19,6 +19,19 @@ func ConfigFile() (string, error) {
 }
 
 // ConfigDir returns the configuration directory for Packer.
+// NOTE: config directory will change depending on operating system dependent
+// For Windows:
+//   PACKER_CONFIG_DIR=""           ConfigDir() => "/{homeDir()}/packer.config/
+//   PACKER_CONFIG_DIR="bar"        ConfigDir() => "/bar/packer.config/
+//
+// NOTE: Default_config_present=TRUE means that there is configuration directory at old location => $HOME/.packer.d
+// NOTE: This is not list all permutations, just some examples, view the
+// configDir function for your OS for the exact logic
+// For Unix:
+//   PACKER_CONFIG_DIR=""    Default_config_present=FALSE XDG_CONFIG_HOME=""    ConfigDir() => "$HOME/.config/packer
+//   PACKER_CONFIG_DIR="bar" Default_config_present=FALSE	XDG_CONFIG_HOME=""    ConfigDir() => "/bar/.packer.d/
+//   PACKER_CONFIG_DIR=""    Default_config_present=TRUE 	XDG_CONFIG_HOME=""    ConfigDir() => "/$HOME/.packer.d/
+//   PACKER_CONFIG_DIR=""    Default_config_present=TRUE 	XDG_CONFIG_HOME="bar" ConfigDir() => "/bar/.packer.d/
 func ConfigDir() (string, error) {
 	return configDir()
 }


### PR DESCRIPTION
Addressing last comment from @azr on [previous pr](https://github.com/hashicorp/packer-plugin-sdk/pull/68) before it got merged to update comments to be more accurate and fix issues in comments. @azr Please let me know if there is anything else I should update with these comments. 

Addresses: [hashicorp/packer#9007](https://github.com/hashicorp/packer/issues/9007)