### PR TITLE
store source image url that was actually used, for recordkeeping

### DIFF
--- a/multistep/commonsteps/step_download.go
+++ b/multistep/commonsteps/step_download.go
@@ -96,6 +96,8 @@ func (s *StepDownload) Run(ctx context.Context, state multistep.StateBag) multis
 		}
 		if err == nil {
 			state.Put(s.ResultKey, dst)
+			// Track the URL you actually used for the download.
+			stete.Put("SourceImageURL", source)
 			return multistep.ActionContinue
 		}
 		// may be another url will work

--- a/multistep/commonsteps/step_download.go
+++ b/multistep/commonsteps/step_download.go
@@ -97,7 +97,7 @@ func (s *StepDownload) Run(ctx context.Context, state multistep.StateBag) multis
 		if err == nil {
 			state.Put(s.ResultKey, dst)
 			// Track the URL you actually used for the download.
-			stete.Put("SourceImageURL", source)
+			state.Put("SourceImageURL", source)
 			return multistep.ActionContinue
 		}
 		// may be another url will work


### PR DESCRIPTION
Stores the iso url that was actually used, in case there were several options. This will be useful for tracking image provenance in the HCP Packer registry, for iso builds. I need this information in the vsphere iso builder. 