### PR TITLE
Fix plugin-check cmd for provisioner only plugins

### DIFF
--- a/cmd/packer-sdc/internal/plugincheck/README.md
+++ b/cmd/packer-sdc/internal/plugincheck/README.md
@@ -1,5 +1,5 @@
 ## `plugin-check`
 
-`plugin-check` will check wether a plugin binary seems to work with packer.
+`plugin-check` will check whether a plugin binary seems to work with packer.
 
 Use: `packer-sdc plugin-check packer-plugin-happy-cloud`

--- a/cmd/packer-sdc/internal/plugincheck/cmd.go
+++ b/cmd/packer-sdc/internal/plugincheck/cmd.go
@@ -79,7 +79,7 @@ func (cmd *Command) run(args []string) error {
 		return errors.New("APIVersion needs to be set")
 	}
 
-	if len(desc.Builders) == 0 && len(desc.PostProcessors) == 0 && len(desc.Datasources) == 0 {
+	if len(desc.Builders) == 0 && len(desc.PostProcessors) == 0 && len(desc.Datasources) == 0 && len(desc.Provisioners) == 0 {
 		return errors.New("this plugin defines no component.")
 	}
 	return nil
@@ -92,6 +92,7 @@ type pluginDescription struct {
 	Builders       []string `json:"builders"`
 	PostProcessors []string `json:"post_processors"`
 	Datasources    []string `json:"datasources"`
+	Provisioners   []string `json:"provisioners"`
 }
 
 func isOldPlugin(pluginName string) bool {


### PR DESCRIPTION
Before change
```
~>  packer-sdc plugin-check packer-plugin-puppet
2021/11/11 14:06:49 this plugin defines no component.
```

After Change
```
~>   packer-sdc plugin-check packer-plugin-puppet && echo $?
0
```
