### PR TITLE
draft - fix: clear stdin before ask

### DIFF
--- a/packer/ui.go
+++ b/packer/ui.go
@@ -64,6 +64,13 @@ func (rw *BasicUi) Ask(query string) (string, error) {
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 	defer signal.Stop(sigCh)
 
+	// Clearing stdin prior to asking question then reading input
+	_, err := rw.TTY.ReadString()
+	if err != nil {
+		log.Printf("ui: err cleaning stdin,  err: %s", err)
+		return "", err
+	}
+
 	log.Printf("ui: ask: %s", query)
 	if query != "" {
 		if _, err := fmt.Fprint(rw.Writer, query+" "); err != nil {


### PR DESCRIPTION
### Describe change

Attempting to clean stdin before ask by running tty `ReadString` prior to asking statement

### Tests
Not sure the best way to test this... Looks like most tests here and in packer repo use mock ui for testing. 

Closes [packer 11288](https://github.com/hashicorp/packer/issues/11288)
