### PR TITLE
Fix file path in comments for windows

### DIFF
--- a/cmd/packer-sdc/internal/struct-markdown/struct_markdown.go
+++ b/cmd/packer-sdc/internal/struct-markdown/struct_markdown.go
@@ -80,6 +80,8 @@ func (cmd *Command) Run(args []string) int {
 		log.Fatalf("ParseFile: %+v", err)
 	}
 
+	canonicalFilePath := filepath.ToSlash(filePath)
+
 	for _, decl := range f.Decls {
 		typeDecl, ok := decl.(*ast.GenDecl)
 		if !ok {
@@ -96,23 +98,23 @@ func (cmd *Command) Run(args []string) int {
 
 		fields := structDecl.Fields.List
 		header := Struct{
-			SourcePath: filePath,
+			SourcePath: canonicalFilePath,
 			Name:       typeSpec.Name.Name,
 			Filename:   typeSpec.Name.Name + ".mdx",
 			Header:     strings.TrimSpace(typeDecl.Doc.Text()),
 		}
 		dataSourceOutput := Struct{
-			SourcePath: filePath,
+			SourcePath: canonicalFilePath,
 			Name:       typeSpec.Name.Name,
 			Filename:   typeSpec.Name.Name + ".mdx",
 		}
 		required := Struct{
-			SourcePath: filePath,
+			SourcePath: canonicalFilePath,
 			Name:       typeSpec.Name.Name,
 			Filename:   typeSpec.Name.Name + "-required.mdx",
 		}
 		notRequired := Struct{
-			SourcePath: filePath,
+			SourcePath: canonicalFilePath,
 			Name:       typeSpec.Name.Name,
 			Filename:   typeSpec.Name.Name + "-not-required.mdx",
 		}

--- a/cmd/packer-sdc/internal/struct-markdown/struct_markdown_test.go
+++ b/cmd/packer-sdc/internal/struct-markdown/struct_markdown_test.go
@@ -2,6 +2,8 @@ package struct_markdown
 
 import (
 	"fmt"
+	"io/ioutil"
+	"strings"
 	"testing"
 
 	. "github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc/internal/cmd"
@@ -34,6 +36,14 @@ func TestCommand_Run(t *testing.T) {
 			cmd := &Command{}
 			if got := cmd.Run(tt.args); got != tt.want {
 				t.Errorf("CMD.Run() = %v, want %v", got, tt.want)
+			}
+			targetedPath := strings.TrimPrefix(tt.args[0], "../test-data/packer-plugin-happycloud/")
+			for _, p := range tt.FileCheck.ExpectedFiles() {
+				raw, _ := ioutil.ReadFile(p)
+				content := string(raw)
+				if !strings.Contains(content, targetedPath) {
+					t.Errorf("%s must contain '%s'. Its content is:\n%s", p, targetedPath, content)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
This pull request fixes #104 by forcing the file path in the files generated by packer-sdc to use forward slashes regardless of the OS where packer-sdc is used.