### PR TITLE
Update exit_code.go

### DIFF
--- a/shell/exit_code.go
+++ b/shell/exit_code.go
@@ -33,7 +33,7 @@ func (e *ErrorInvalidExitCode) Error() string {
 	if e == nil {
 		return "<nil>"
 	}
-	return fmt.Sprintf("Script exited with non-zero exit status: %d."+
+	return fmt.Sprintf("Script exited with non-zero exit status: %d. "+
 		"Allowed exit codes are: %v",
 		e.Code, e.Allowed)
 }


### PR DESCRIPTION
This is a purely cosmetic patch to insert a space between the invalid exit code and the next sentence, which otherwise runs together.