### PR TITLE
Update go-getter client options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.0 (Upcoming)
+
+* multistep/commonsteps: Update settings for the default go-getter client to prevent arbitrary host access via go-getter's path traversal, symlink processing, and command injection flaws.
+* multistep/commonsteps: Disable support for the `X-Terraform-Get` header to mitigate against protocol switching, endless redirect, and configuration bypass abuse of custom HTTP response header processing.
+* multistep/commonsteps: Add default timeouts to the GitGetter, HgGetter, S3Getter, and GcsGetter getters to mitigate against resource exhaustion when calling out to external command line applications.
+* sdk: Bump github.com/hashicorp/go-getter/v2, github.com/hashicorp/go-getter/gcs/v2, github.com/hashicorp/go-getter/s3/v2 to address a number of security vulnerabilities as defined in [HCSEC-2022-13](https://discuss.hashicorp.com/t/hcsec-2022-13-multiple-vulnerabilities-in-go-getter-library/39930)
+
 ## 0.2.13 (May 11, 2022)
 
 * cmd/packer-sdc: Update golang.org/x/tools to fix internal package errors when running code generation commands with Go 1.18 [GH-108](https://github.com/hashicorp/packer-plugin-sdk/pull/108)

--- a/multistep/commonsteps/step_download.go
+++ b/multistep/commonsteps/step_download.go
@@ -56,7 +56,8 @@ type StepDownload struct {
 }
 
 var defaultGetterClient = getter.Client{
-	Getters: getter.Getters,
+	Getters:         getter.Getters,
+	DisableSymlinks: true,
 }
 
 func init() {

--- a/multistep/commonsteps/step_download.go
+++ b/multistep/commonsteps/step_download.go
@@ -56,14 +56,18 @@ type StepDownload struct {
 	Extension string
 }
 
+// defaultGetterReadTimeout is the read timeout for downloading operations via go-getter.
+// The timeout must be long enough to accommodate large/slow downloads.
+const defaultGetterReadTimeout time.Duration = 30 * time.Minute
+
 var defaultGetterClient = getter.Client{
-	// Disable writing and reading through symlinks
+	// Disable writing and reading through symlinks.
 	DisableSymlinks: true,
 	// The order of the Getters in the list may affect the result
 	// depending if the Request.Src is detected as valid by multiple getters
 	Getters: []getter.Getter{
 		&getter.GitGetter{
-			Timeout: 5 * time.Minute,
+			Timeout: defaultGetterReadTimeout,
 			Detectors: []getter.Detector{
 				new(getter.GitHubDetector),
 				new(getter.GitDetector),
@@ -72,22 +76,22 @@ var defaultGetterClient = getter.Client{
 			},
 		},
 		&getter.HgGetter{
-			Timeout: 5 * time.Minute,
+			Timeout: defaultGetterReadTimeout,
 		},
 		new(getter.SmbClientGetter),
 		new(getter.SmbMountGetter),
 		&getter.HttpGetter{
 			Netrc:                 true,
 			XTerraformGetDisabled: true,
-			HeadFirstTimeout:      10 * time.Second,
-			ReadTimeout:           30 * time.Second,
+			HeadFirstTimeout:      defaultGetterReadTimeout,
+			ReadTimeout:           defaultGetterReadTimeout,
 		},
 		new(getter.FileGetter),
 		&gcs.Getter{
-			Timeout: 5 * time.Minute,
+			Timeout: defaultGetterReadTimeout,
 		},
 		&s3.Getter{
-			Timeout: 5 * time.Minute,
+			Timeout: defaultGetterReadTimeout,
 		},
 	},
 }

--- a/multistep/commonsteps/step_download.go
+++ b/multistep/commonsteps/step_download.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	gcs "github.com/hashicorp/go-getter/gcs/v2"
 	s3 "github.com/hashicorp/go-getter/s3/v2"
@@ -61,8 +62,14 @@ var defaultGetterClient = getter.Client{
 }
 
 func init() {
-	defaultGetterClient.Getters = append(defaultGetterClient.Getters, new(gcs.Getter))
-	defaultGetterClient.Getters = append(defaultGetterClient.Getters, new(s3.Getter))
+	gcsGetter := gcs.Getter{
+		Timeout: 5 * time.Minute,
+	}
+	defaultGetterClient.Getters = append(defaultGetterClient.Getters, &gcsGetter)
+	s3Getter := s3.Getter{
+		Timeout: 5 * time.Minute,
+	}
+	defaultGetterClient.Getters = append(defaultGetterClient.Getters, &s3Getter)
 }
 
 func (s *StepDownload) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {


### PR DESCRIPTION
* Disable reading and writing files through symlinks
* Add timeouts for GCS and S3 getters

Related to: https://github.com/hashicorp/packer-internal-issues/issues/38 (internal only)