### PR TITLE
Change step_create_cdrom_tests to pass on Windows

### DIFF
--- a/multistep/commonsteps/step_create_cdrom_test.go
+++ b/multistep/commonsteps/step_create_cdrom_test.go
@@ -52,10 +52,10 @@ func checkFiles(t *testing.T, rootFolder string, expected map[string]string) {
 
 		if !d.IsDir() {
 			name, _ := filepath.Rel(rootFolder, path)
-
-			expectedContent, ok := expected[name]
+			nameSlashSafe := filepath.ToSlash(name)
+			expectedContent, ok := expected[nameSlashSafe]
 			if !ok {
-				t.Fatalf("unexpected file: %s", name)
+				t.Fatalf("unexpected file: %s", nameSlashSafe)
 			}
 
 			content, err := ioutil.ReadFile(path)
@@ -63,10 +63,10 @@ func checkFiles(t *testing.T, rootFolder string, expected map[string]string) {
 				t.Fatalf("reading file: %s", err)
 			}
 			if string(content) != expectedContent {
-				t.Fatalf("unexpected content: %s", name)
+				t.Fatalf("unexpected content: %s", nameSlashSafe)
 			}
 
-			delete(expected, name)
+			delete(expected, nameSlashSafe)
 		}
 
 		return nil


### PR DESCRIPTION
A little change that was found during setting up the project on Windows.

The tests were relying on unix paths "/" while on Windows we have "\"
and tests were failing in checkFiles with the such messages as:

unexpected file: subfolder\meta-data

