### PR TITLE
ssh: only rely on timeout/retries if one is set

### DIFF
--- a/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/SSH-not-required.mdx
+++ b/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/SSH-not-required.mdx
@@ -44,11 +44,12 @@
 - `ssh_timeout` (duration string | ex: "1h5m2s") - The time to wait for SSH to become available. Packer uses this to
   determine when the machine has booted so this is usually quite long.
   Example value: `10m`.
+  This defaults to `5m`, unless `ssh_handshake_attempts` is set.
 
 - `ssh_disable_agent_forwarding` (bool) - If true, SSH agent forwarding will be disabled. Defaults to `false`.
 
-- `ssh_handshake_attempts` (int) - The number of handshakes to attempt with SSH once it can connect. This
-  defaults to `10`.
+- `ssh_handshake_attempts` (int) - The number of handshakes to attempt with SSH once it can connect.
+  This defaults to `10`, unless a `ssh_timeout` is set.
 
 - `ssh_bastion_host` (string) - A bastion host to use for the actual SSH connection.
 


### PR DESCRIPTION
In a configuration, when either the SSH timeout or the SSH handshake
retries are set, the other attribute would also be set to its default
value.

This in turn could cause a problem where a user expects his choice to be
the one that makes the final decision to abort, but in the end this
choice could cause the build to be cancelled independently as the other
setting may cause a premature cancellation.

To avoid this, we clarify the documentation, and ensure that when one is
set, the other will be ignored.

Closes: #87 