### PR TITLE
Logging ssh bastion

### DIFF
--- a/communicator/config.go
+++ b/communicator/config.go
@@ -547,10 +547,10 @@ func (c *Config) prepareSSH(ctx *interpolate.Context) []error {
 		}
 	}
 
-	if c.SSHBastionHost != "" && !c.SSHBastionAgentAuth {
-		if c.SSHBastionPassword == "" && c.SSHBastionPrivateKeyFile == "" {
+	if c.SSHBastionHost != "" {
+		if c.SSHBastionPassword == "" && c.SSHBastionPrivateKeyFile == "" && !c.SSHBastionAgentAuth {
 			errs = append(errs, errors.New(
-				"ssh_bastion_password or ssh_bastion_private_key_file must be specified"))
+				"ssh_bastion_password, ssh_bastion_private_key_file or ssh_bastion_agent_auth must be specified"))
 		} else if c.SSHBastionPrivateKeyFile != "" {
 			path, err := pathing.ExpandUser(c.SSHBastionPrivateKeyFile)
 			if err != nil {

--- a/communicator/step_connect_ssh.go
+++ b/communicator/step_connect_ssh.go
@@ -165,6 +165,8 @@ func (s *StepConnectSSH) waitForSSH(state multistep.StateBag, ctx context.Contex
 		var connFunc func() (net.Conn, error)
 		address := fmt.Sprintf("%s:%d", host, port)
 		if bAddr != "" {
+			log.Printf("[INFO] connecting with SSH to host %s through bastion at %s",
+				address, bAddr)
 			// We're using a bastion host, so use the bastion connfunc
 			connFunc = ssh.BastionConnectFunc(
 				bProto, bAddr, bConf, "tcp", address)

--- a/sdk-internals/communicator/ssh/connect.go
+++ b/sdk-internals/communicator/ssh/connect.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"time"
 
@@ -61,6 +62,9 @@ func BastionConnectFunc(
 		if err != nil {
 			return nil, fmt.Errorf("Error connecting to bastion: %s", err)
 		}
+
+		log.Println("[DEBUG] connected to bastion host")
+		log.Println("[DEBUG] attempting connection to destination host")
 
 		// Connect through to the end host
 		conn, err := bastion.Dial(proto, addr)


### PR DESCRIPTION
In order to make it easier to follow when connecting with a bastion to a SSH host, we add another layer of logging related to these actions.

Related to: https://github.com/hashicorp/packer/issues/11719