### PR TITLE
communicator: fix SSH config typo

### DIFF
--- a/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/SSH-not-required.mdx
+++ b/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/SSH-not-required.mdx
@@ -28,7 +28,7 @@
   (unless the user has set the `-debug` flag). Defaults to "false";
   currently only works on guests with `sed` installed.
 
-- `ssh_key_exchange_algorithms` ([]string) - If set, Packer will override the value of key exchange (kex) altorighms
+- `ssh_key_exchange_algorithms` ([]string) - If set, Packer will override the value of key exchange (kex) algorithms
   supported by default by golang. Acceptable values include:
   "curve25519-sha256@libssh.org", "ecdh-sha2-nistp256",
   "ecdh-sha2-nistp384", "ecdh-sha2-nistp521",

--- a/communicator/config.go
+++ b/communicator/config.go
@@ -103,7 +103,7 @@ type SSH struct {
 	// (unless the user has set the `-debug` flag). Defaults to "false";
 	// currently only works on guests with `sed` installed.
 	SSHClearAuthorizedKeys bool `mapstructure:"ssh_clear_authorized_keys"`
-	// If set, Packer will override the value of key exchange (kex) altorighms
+	// If set, Packer will override the value of key exchange (kex) algorithms
 	// supported by default by golang. Acceptable values include:
 	// "curve25519-sha256@libssh.org", "ecdh-sha2-nistp256",
 	// "ecdh-sha2-nistp384", "ecdh-sha2-nistp521",


### PR DESCRIPTION
Fix small typo in the comment for an SSH configuration option where algorithm was misspelled.