### PR TITLE
Update docs links

### DIFF
--- a/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/WinRM-not-required.mdx
+++ b/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/WinRM-not-required.mdx
@@ -8,7 +8,7 @@
   
   NOTE: If using an Amazon EBS builder, you can specify the interface
   WinRM connects to via
-  [`ssh_interface`](/docs/builders/amazon-ebs#ssh_interface)
+  [`ssh_interface`](/packer/plugins/builders/amazon/ebs#ssh_interface)
 
 - `winrm_no_proxy` (bool) - Setting this to `true` adds the remote
   `host:port` to the `NO_PROXY` environment variable. This has the effect of

--- a/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/multistep/commonsteps/FloppyConfig.mdx
+++ b/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/multistep/commonsteps/FloppyConfig.mdx
@@ -7,6 +7,6 @@ this setting get placed into the root directory of the floppy and the floppy
 is attached as the first floppy device. The summary size of the listed files
 must not exceed 1.44 MB. The supported ways to move large files into the OS
 are using `http_directory` or [the file
-provisioner](/docs/provisioners/file).
+provisioner](/packer/plugins/provisioners/file).
 
 <!-- End of code generated from the comments of the FloppyConfig struct in multistep/commonsteps/floppy_config.go; -->

--- a/communicator/config.go
+++ b/communicator/config.go
@@ -221,7 +221,7 @@ type WinRM struct {
 	//
 	// NOTE: If using an Amazon EBS builder, you can specify the interface
 	// WinRM connects to via
-	// [`ssh_interface`](/docs/builders/amazon-ebs#ssh_interface)
+	// [`ssh_interface`](/packer/plugins/builders/amazon/ebs#ssh_interface)
 	WinRMHost string `mapstructure:"winrm_host"`
 	// Setting this to `true` adds the remote
 	// `host:port` to the `NO_PROXY` environment variable. This has the effect of

--- a/multistep/commonsteps/floppy_config.go
+++ b/multistep/commonsteps/floppy_config.go
@@ -18,7 +18,7 @@ import (
 // is attached as the first floppy device. The summary size of the listed files
 // must not exceed 1.44 MB. The supported ways to move large files into the OS
 // are using `http_directory` or [the file
-// provisioner](/docs/provisioners/file).
+// provisioner](/packer/plugins/provisioners/file).
 type FloppyConfig struct {
 	// A list of files to place onto a floppy disk that is attached when the VM
 	// is booted. Currently, no support exists for creating sub-directories on


### PR DESCRIPTION
Links are redirecting to the wrong page on the new website.