### PR TITLE
Add boot steps configuration option

### DIFF
--- a/bootcommand/config_test.go
+++ b/bootcommand/config_test.go
@@ -28,6 +28,15 @@ func TestConfigPrepare(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("bad: %#v", errs)
 	}
+
+	// Test boot command and boot steps
+	c = new(BootConfig)
+	c.BootCommand = []string{"a", "b"}
+	c.BootSteps = [][]string{{"a"}, {"b"}}
+	errs = c.Prepare(&interpolate.Context{})
+	if len(errs) == 0 {
+		t.Fatal("should error")
+	}
 }
 
 func TestVNCConfigPrepare(t *testing.T) {

--- a/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/bootcommand/BootConfig-not-required.mdx
+++ b/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/bootcommand/BootConfig-not-required.mdx
@@ -19,4 +19,43 @@
   well, and are covered in the section below on the boot command. If this
   is not specified, it is assumed the installer will start itself.
 
+- `boot_steps` ([][]string) - This is an array of tuples of boot commands, to type when the virtual
+  machine is booted. The first element of the tuple is the actual boot
+  command. The second element of the tuple, which is optional, is a
+  description of what the boot command does. This is intended to be used for
+  interactive installers that requires many commands to complete the
+  installation. Both the command and the description will be printed when
+  logging is enabled. When debug mode is enabled Packer will pause after
+  typing each boot command. This will make it easier to follow along the
+  installation process and make sure the Packer and the installer are in
+  sync. `boot_steps` and `boot_commands` are mutually exclusive.
+  
+  Example:
+  
+  In HCL:
+  ```hcl
+  boot_steps = [
+    ["1<enter><wait5>", "Install NetBSD"],
+    ["a<enter><wait5>", "Installation messages in English"],
+    ["a<enter><wait5>", "Keyboard type: unchanged"],
+  
+    ["a<enter><wait5>", "Install NetBSD to hard disk"],
+    ["b<enter><wait5>", "Yes"]
+  ]
+  ```
+  
+  In JSON:
+  ```json
+  {
+    "boot_steps": [
+      ["1<enter><wait5>", "Install NetBSD"],
+      ["a<enter><wait5>", "Installation messages in English"],
+      ["a<enter><wait5>", "Keyboard type: unchanged"],
+  
+      ["a<enter><wait5>", "Install NetBSD to hard disk"],
+      ["b<enter><wait5>", "Yes"]
+    ]
+  }
+  ```
+
 <!-- End of code generated from the comments of the BootConfig struct in bootcommand/config.go; -->


### PR DESCRIPTION
Adds a new configuration option called `boot_steps`. This is an array of tuples of boot commands, to type when the virtual machine is booted. The first element of the tuple is the actual boot command. The second element of the tuple, which is optional, is a description of what the boot command does. This is intended to be used for interactive installers that requires many commands to complete the installation.

Both the command and the description will be printed when logging is enabled. When debug mode is enabled Packer will pause after typing each boot command. This will make it easier to follow along the installation process and make sure the Packer and the installer are in sync.

This is the SDK part of https://github.com/hashicorp/packer-plugin-qemu/pull/103.