### PR TITLE
iso_config: Warn when checksum is "<unknown>".

### DIFF
--- a/multistep/commonsteps/iso_config.go
+++ b/multistep/commonsteps/iso_config.go
@@ -144,6 +144,11 @@ func (c *ISOConfig) Prepare(*interpolate.Context) (warnings []string, errs []err
 			"A checksum of 'none' was specified. Since ISO files are so big,\n"+
 				"a checksum is highly recommended.")
 		return warnings, errs
+	} else if c.ISOChecksum == "<unknown>" {
+		warnings = append(warnings,
+			"A checksum of '<unknown>' was specified. This is expected when\n"+
+				"running 'packer validate' and the checksum is set using a datasource.")
+		return warnings, errs
 	} else if c.ISOChecksum == "" {
 		errs = append(errs, fmt.Errorf("A checksum must be specified"))
 	} else {

--- a/multistep/commonsteps/iso_config_test.go
+++ b/multistep/commonsteps/iso_config_test.go
@@ -98,6 +98,17 @@ func TestISOConfigPrepare_ISOChecksumType(t *testing.T) {
 	if err != nil {
 		t.Fatalf("should not have error: %s", err)
 	}
+
+	// Test <unknown>
+	i = testISOConfig()
+	i.ISOChecksum = "<unknown>"
+	warns, err = i.Prepare(nil)
+	if len(warns) == 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
 }
 
 func TestISOConfigPrepare_ISOUrl(t *testing.T) {


### PR DESCRIPTION
Give a warning instead of an error when the iso checksum is `"<unknown>"`. Otherwise `packer validate` always gives an error when a datasource is used to set the checksum, even if the template file is correct.

Closes #143 