### PR TITLE
communicator: add note to docs on protocol/Windows

### DIFF
--- a/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/SSH-not-required.mdx
+++ b/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/SSH-not-required.mdx
@@ -74,6 +74,11 @@
 
 - `ssh_file_transfer_method` (string) - `scp` or `sftp` - How to transfer files, Secure copy (default) or SSH
   File Transfer Protocol.
+  
+  **NOTE**: Guests using Windows with Win32-OpenSSH v9.1.0.0p1-Beta, scp
+  (the default protocol for copying data) returns a a non-zero error code since the MOTW
+  cannot be set, which cause any file transfer to fail. As a workaround you can override the transfer protocol
+  with SFTP instead `ssh_file_transfer_protocol = "sftp"`.
 
 - `ssh_proxy_host` (string) - A SOCKS proxy host to use for SSH connection
 

--- a/communicator/config.go
+++ b/communicator/config.go
@@ -165,6 +165,11 @@ type SSH struct {
 	SSHBastionCertificateFile string `mapstructure:"ssh_bastion_certificate_file"`
 	// `scp` or `sftp` - How to transfer files, Secure copy (default) or SSH
 	// File Transfer Protocol.
+	//
+	// **NOTE**: Guests using Windows with Win32-OpenSSH v9.1.0.0p1-Beta, scp
+	// (the default protocol for copying data) returns a a non-zero error code since the MOTW
+	// cannot be set, which cause any file transfer to fail. As a workaround you can override the transfer protocol
+	// with SFTP instead `ssh_file_transfer_protocol = "sftp"`.
 	SSHFileTransferMethod string `mapstructure:"ssh_file_transfer_method"`
 	// A SOCKS proxy host to use for SSH connection
 	SSHProxyHost string `mapstructure:"ssh_proxy_host"`


### PR DESCRIPTION
Recently, an update to Windows's default SSH implementation added an extra check for the mark-of-the-web to their code, which if in verbose mode, ends-up producing an error log, and terminates the process with a non-zero error code, even if the transfer is successful.

Because of this, scp transfers fail all the time in such an environment, and the recommended workaround for now is to set sftp as the transfer protocol, as this one sets the mark-of-the-web successfully, and therefore ends with a 0 error code.

Since this is surprising behaviour to users, we add a paragraph to the docs, so they know about this workaround.