### PR TITLE
ssh: fix DownloadDir empty response check

### DIFF
--- a/sdk-internals/communicator/ssh/communicator.go
+++ b/sdk-internals/communicator/ssh/communicator.go
@@ -207,7 +207,7 @@ func (c *comm) DownloadDir(src string, dst string, excl []string) error {
 				return err
 			}
 
-			if len(fi) < 0 {
+			if len(fi) == 0 {
 				return fmt.Errorf("empty response from server")
 			}
 


### PR DESCRIPTION
We used to check if a ssh server returns an empty payload with a len(fi) < 0, which can never succeed as len never returns negative values.

This commit changes the condition to an == instead.