### PR TITLE
Update links used in embedded documentation partials

### DIFF
--- a/bootcommand/config.go
+++ b/bootcommand/config.go
@@ -147,7 +147,7 @@ const PackerKeyDefault = 100 * time.Millisecond
 // ```
 //
 // For more examples of various boot commands, see the sample projects from our
-// [community templates page](/community-tools#templates).
+// [community templates page](https://packer.io/community-tools#templates).
 type BootConfig struct {
 	// Time to wait after sending a group of key pressses. The value of this
 	// should be a duration. Examples are `5s` and `1m30s` which will cause

--- a/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/bootcommand/BootConfig.mdx
+++ b/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/bootcommand/BootConfig.mdx
@@ -125,6 +125,6 @@ boot_command = [
 ```
 
 For more examples of various boot commands, see the sample projects from our
-[community templates page](/community-tools#templates).
+[community templates page](https://packer.io/community-tools#templates).
 
 <!-- End of code generated from the comments of the BootConfig struct in bootcommand/config.go; -->

--- a/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/SSH-not-required.mdx
+++ b/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/SSH-not-required.mdx
@@ -9,7 +9,7 @@
 
 - `ssh_password` (string) - A plaintext password to use to authenticate with SSH.
 
-- `ssh_ciphers` ([]string) - This overrides the value of ciphers supported by default by golang.
+- `ssh_ciphers` ([]string) - This overrides the value of ciphers supported by default by Golang.
   The default value is [
     "aes128-gcm@openssh.com",
     "chacha20-poly1305@openssh.com",
@@ -29,7 +29,7 @@
   currently only works on guests with `sed` installed.
 
 - `ssh_key_exchange_algorithms` ([]string) - If set, Packer will override the value of key exchange (kex) algorithms
-  supported by default by golang. Acceptable values include:
+  supported by default by Golang. Acceptable values include:
   "curve25519-sha256@libssh.org", "ecdh-sha2-nistp256",
   "ecdh-sha2-nistp384", "ecdh-sha2-nistp521",
   "diffie-hellman-group14-sha1", and "diffie-hellman-group1-sha1".

--- a/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/multistep/commonsteps/FloppyConfig.mdx
+++ b/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/multistep/commonsteps/FloppyConfig.mdx
@@ -7,6 +7,6 @@ this setting get placed into the root directory of the floppy and the floppy
 is attached as the first floppy device. The summary size of the listed files
 must not exceed 1.44 MB. The supported ways to move large files into the OS
 are using `http_directory` or [the file
-provisioner](/packer/plugins/provisioners/file).
+provisioner](/packer/docs/provisioners/file).
 
 <!-- End of code generated from the comments of the FloppyConfig struct in multistep/commonsteps/floppy_config.go; -->

--- a/communicator/config.go
+++ b/communicator/config.go
@@ -87,7 +87,7 @@ type SSH struct {
 	// a 36 character unique identifier.
 	SSHTemporaryKeyPairName string `mapstructure:"temporary_key_pair_name" undocumented:"true"`
 	SSHTemporaryKeyPair     `mapstructure:",squash"`
-	// This overrides the value of ciphers supported by default by golang.
+	// This overrides the value of ciphers supported by default by Golang.
 	// The default value is [
 	//   "aes128-gcm@openssh.com",
 	//   "chacha20-poly1305@openssh.com",
@@ -107,7 +107,7 @@ type SSH struct {
 	// currently only works on guests with `sed` installed.
 	SSHClearAuthorizedKeys bool `mapstructure:"ssh_clear_authorized_keys"`
 	// If set, Packer will override the value of key exchange (kex) algorithms
-	// supported by default by golang. Acceptable values include:
+	// supported by default by Golang. Acceptable values include:
 	// "curve25519-sha256@libssh.org", "ecdh-sha2-nistp256",
 	// "ecdh-sha2-nistp384", "ecdh-sha2-nistp521",
 	// "diffie-hellman-group14-sha1", and "diffie-hellman-group1-sha1".

--- a/multistep/commonsteps/floppy_config.go
+++ b/multistep/commonsteps/floppy_config.go
@@ -21,7 +21,7 @@ import (
 // is attached as the first floppy device. The summary size of the listed files
 // must not exceed 1.44 MB. The supported ways to move large files into the OS
 // are using `http_directory` or [the file
-// provisioner](/packer/plugins/provisioners/file).
+// provisioner](/packer/docs/provisioners/file).
 type FloppyConfig struct {
 	// A list of files to place onto a floppy disk that is attached when the VM
 	// is booted. Currently, no support exists for creating sub-directories on


### PR DESCRIPTION
- Migrates the formats of links in Markdown content as part of the [Docs
  Content Link Rewrites
  project](https://docs.google.com/document/d/1WaSyvoVPS-YCNiSPX0ynGpvc1gySEcpbrRoQVhimQCA/edit)
