### PR TITLE
Remove ioutil in favour of io and os packages and exclude crypto/dsa …

### DIFF
--- a/acctest/provisioneracc/provisioners.go
+++ b/acctest/provisioneracc/provisioners.go
@@ -6,7 +6,7 @@ package provisioneracc
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -157,7 +157,7 @@ func LoadBuilderFragment(templateFragmentPath string) (string, error) {
 	}
 	defer fragmentFile.Close()
 
-	fragmentString, err := ioutil.ReadAll(fragmentFile)
+	fragmentString, err := io.ReadAll(fragmentFile)
 	if err != nil {
 		return "", fmt.Errorf("Unable to read %s", fragmentAbsPath)
 	}

--- a/acctest/testutils/utils.go
+++ b/acctest/testutils/utils.go
@@ -8,7 +8,6 @@ package testutils
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
@@ -48,7 +47,7 @@ func GetArtifact(manifestfilepath string) (ManifestFile, error) {
 	//   "last_run_uuid": "81fc083f-0b78-d815-ed3a-2e5f53b36bff"
 	// }
 	manifest := ManifestFile{}
-	data, err := ioutil.ReadFile(manifestfilepath)
+	data, err := os.ReadFile(manifestfilepath)
 	if err != nil {
 		return manifest, fmt.Errorf("failed to open manifest file %s", manifestfilepath)
 	}

--- a/chroot/communicator_test.go
+++ b/chroot/communicator_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestCommunicator_ImplementsCommunicator(t *testing.T) {
-	var raw interface{}
-	raw = &Communicator{}
+	var raw interface{} = &Communicator{}
 
 	if _, ok := raw.(packersdk.Communicator); !ok {
 		t.Fatalf("Communicator should be a communicator")

--- a/chroot/step_copy_files_test.go
+++ b/chroot/step_copy_files_test.go
@@ -6,7 +6,7 @@ package chroot
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path"
 	"runtime"
 	"strings"
@@ -23,15 +23,14 @@ func testUI() (packersdk.Ui, func() string) {
 	errorBuffer := &strings.Builder{}
 	ui := &packersdk.BasicUi{
 		Reader:      strings.NewReader(""),
-		Writer:      ioutil.Discard,
+		Writer:      io.Discard,
 		ErrorWriter: errorBuffer,
 	}
 	return ui, errorBuffer.String
 }
 
 func TestCopyFilesCleanupFunc_ImplementsCleanupFunc(t *testing.T) {
-	var raw interface{}
-	raw = new(StepCopyFiles)
+	var raw interface{} = new(StepCopyFiles)
 	if _, ok := raw.(Cleanup); !ok {
 		t.Fatalf("cleanup func should be a CleanupFunc")
 	}
@@ -50,8 +49,7 @@ func TestCopyFiles_Run(t *testing.T) {
 
 	var gotCommand string
 	commandRunCount := 0
-	var wrapper common.CommandWrapper
-	wrapper = func(ran string) (string, error) {
+	var wrapper common.CommandWrapper = func(ran string) (string, error) {
 		gotCommand = ran
 		commandRunCount++
 		return "", nil
@@ -101,8 +99,7 @@ func TestCopyFiles_CopyNothing(t *testing.T) {
 	}
 
 	commandRunCount := 0
-	var wrapper common.CommandWrapper
-	wrapper = func(ran string) (string, error) {
+	var wrapper common.CommandWrapper = func(ran string) (string, error) {
 		commandRunCount++
 		return "", nil
 	}

--- a/chroot/step_mount_extra_test.go
+++ b/chroot/step_mount_extra_test.go
@@ -6,8 +6,7 @@ package chroot
 import "testing"
 
 func TestMountExtraCleanupFunc_ImplementsCleanupFunc(t *testing.T) {
-	var raw interface{}
-	raw = new(StepMountExtra)
+	var raw interface{} = new(StepMountExtra)
 	if _, ok := raw.(Cleanup); !ok {
 		t.Fatalf("cleanup func should be a CleanupFunc")
 	}

--- a/cmd/packer-sdc/internal/cmd/utils.go
+++ b/cmd/packer-sdc/internal/cmd/utils.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,7 +45,7 @@ func (fc FileCheck) Verify(t *testing.T, dir string) {
 		}
 	}
 	for file, expectedContent := range fc.ExpectedContent {
-		content, err := ioutil.ReadFile(filepath.Join(dir, file))
+		content, err := os.ReadFile(filepath.Join(dir, file))
 		if err != nil {
 			t.Fatalf("ioutil.ReadFile: %v", err)
 		}

--- a/cmd/packer-sdc/internal/fs/sync.go
+++ b/cmd/packer-sdc/internal/fs/sync.go
@@ -6,7 +6,6 @@ package fs
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -44,7 +43,7 @@ func SyncDir(src, dst string) error {
 		return errors.Wrapf(err, "cannot mkdir %s", dst)
 	}
 
-	entries, err := ioutil.ReadDir(src)
+	entries, err := os.ReadDir(src)
 	if err != nil {
 		return errors.Wrapf(err, "cannot read directory %s", dst)
 	}
@@ -67,7 +66,7 @@ func SyncDir(src, dst string) error {
 	}
 
 	// Remove files in dst that aren't in src
-	entries, err = ioutil.ReadDir(dst)
+	entries, err = os.ReadDir(dst)
 	if err != nil {
 		return errors.Wrapf(err, "cannot read directory %s", dst)
 	}

--- a/cmd/packer-sdc/internal/renderdocs/renderdocs.go
+++ b/cmd/packer-sdc/internal/renderdocs/renderdocs.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"embed"
 	"flag"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -67,7 +66,7 @@ func (cmd *Command) run(args []string) error {
 }
 
 func RenderDocsFolder(folder, partials string) error {
-	entries, err := ioutil.ReadDir(folder)
+	entries, err := os.ReadDir(folder)
 	if err != nil {
 		return errors.Wrapf(err, "cannot read directory %s", folder)
 	}
@@ -129,7 +128,9 @@ var partialFiles embed.FS
 // getPartial will first try to look for partials in the
 // renderdocs/docs-partials dir. This makes common/shared partials available to
 // all docs with for example:
-//  @include 'packer-plugin-sdk/communicator/Config.mdx'
+//
+//	@include 'packer-plugin-sdk/communicator/Config.mdx'
+//
 // Otherwise it tries to find a partial in/ the actual filesystem.
 func getPartial(partialsDir, partialPath string) ([]byte, error) {
 	if partial, err := partialFiles.ReadFile(strings.Join([]string{"docs-partials", partialPath}, "/")); err == nil {

--- a/cmd/packer-sdc/internal/struct-markdown/struct_markdown.go
+++ b/cmd/packer-sdc/internal/struct-markdown/struct_markdown.go
@@ -8,7 +8,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -72,7 +71,7 @@ func (cmd *Command) Run(args []string) int {
 		log.Fatal("Failed to guess project ROOT. If this is a Packer plugin project please make sure the root directory begins with`packer-plugin-*`")
 	}
 
-	b, err := ioutil.ReadFile(fname)
+	b, err := os.ReadFile(fname)
 	if err != nil {
 		log.Fatalf("ReadFile: %+v", err)
 	}

--- a/cmd/packer-sdc/internal/struct-markdown/struct_markdown_test.go
+++ b/cmd/packer-sdc/internal/struct-markdown/struct_markdown_test.go
@@ -5,7 +5,7 @@ package struct_markdown
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -42,7 +42,7 @@ func TestCommand_Run(t *testing.T) {
 			}
 			targetedPath := strings.TrimPrefix(tt.args[0], "../test-data/packer-plugin-happycloud/")
 			for _, p := range tt.FileCheck.ExpectedFiles() {
-				raw, _ := ioutil.ReadFile(p)
+				raw, _ := os.ReadFile(p)
 				content := string(raw)
 				if !strings.Contains(content, targetedPath) {
 					t.Errorf("%s must contain '%s'. Its content is:\n%s", p, targetedPath, content)

--- a/communicator/config.go
+++ b/communicator/config.go
@@ -9,7 +9,6 @@ package communicator
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"time"
@@ -311,7 +310,7 @@ func (c *Config) ReadSSHPrivateKeyFile() ([]byte, error) {
 			return []byte{}, fmt.Errorf("Error expanding path for SSH private key: %s", err)
 		}
 
-		privateKey, err = ioutil.ReadFile(keyPath)
+		privateKey, err = os.ReadFile(keyPath)
 		if err != nil {
 			return privateKey, fmt.Errorf("Error on reading SSH private key: %s", err)
 		}

--- a/communicator/ssh/key_pair.go
+++ b/communicator/ssh/key_pair.go
@@ -60,7 +60,7 @@ type KeyPair struct {
 // KeyPairFromPrivateKey returns a KeyPair loaded from an existing private key.
 //
 // Supported key pair types include:
-//   - DSA
+//   - DSA (NOTE: deprecated from Go as DSA is not regarded as secure anymore, please consider RSA or ED25519 instead)
 //   - ECDSA
 //   - ED25519
 //   - RSA

--- a/communicator/ssh/key_pair.go
+++ b/communicator/ssh/key_pair.go
@@ -6,7 +6,7 @@ package ssh
 import (
 	"bytes"
 	"crypto"
-	"crypto/dsa"
+	"crypto/dsa" //nolint:all
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -60,10 +60,10 @@ type KeyPair struct {
 // KeyPairFromPrivateKey returns a KeyPair loaded from an existing private key.
 //
 // Supported key pair types include:
-// 	- DSA
-// 	- ECDSA
-// 	- ED25519
-// 	- RSA
+//   - DSA
+//   - ECDSA
+//   - ED25519
+//   - RSA
 func KeyPairFromPrivateKey(config FromPrivateKeyConfig) (KeyPair, error) {
 	privateKey, err := gossh.ParseRawPrivateKey(config.RawPrivateKeyPemBlock)
 	if err != nil {

--- a/communicator/ssh/key_pair_test.go
+++ b/communicator/ssh/key_pair_test.go
@@ -5,7 +5,7 @@ package ssh
 
 import (
 	"bytes"
-	"crypto/dsa"
+	"crypto/dsa" //nolint:all
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"fmt"

--- a/communicator/ssh/ssh.go
+++ b/communicator/ssh/ssh.go
@@ -8,7 +8,7 @@ package ssh
 import (
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"time"
 
@@ -22,7 +22,7 @@ func parseKeyFile(path string) ([]byte, error) {
 	}
 	defer f.Close()
 
-	keyBytes, err := ioutil.ReadAll(f)
+	keyBytes, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func ReadCertificate(certificatePath string, keySigner ssh.Signer) (ssh.Signer, 
 	}
 
 	// Load the certificate
-	cert, err := ioutil.ReadFile(certificatePath)
+	cert, err := os.ReadFile(certificatePath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read certificate file: %v", err)
 	}

--- a/communicator/sshkey/generate.go
+++ b/communicator/sshkey/generate.go
@@ -4,7 +4,7 @@
 package sshkey
 
 import (
-	"crypto/dsa"
+	"crypto/dsa" //nolint:all
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"

--- a/communicator/step_connect_ssh.go
+++ b/communicator/step_connect_ssh.go
@@ -7,14 +7,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"golang.org/x/term"
 	"io"
 	"log"
 	"net"
 	"os"
 	"strings"
 	"time"
-
-	"golang.org/x/crypto/ssh/terminal"
 
 	helperssh "github.com/hashicorp/packer-plugin-sdk/communicator/ssh"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
@@ -261,7 +260,7 @@ func sshBastionConfig(config *Config) (*gossh.ClientConfig, error) {
 
 	if config.SSHBastionInteractive {
 		var c io.ReadWriteCloser
-		if terminal.IsTerminal(int(os.Stdin.Fd())) {
+		if term.IsTerminal(int(os.Stdin.Fd())) {
 			c = os.Stdin
 		} else {
 			tty, err := os.Open("/dev/tty")

--- a/communicator/step_debug_ssh_keys.go
+++ b/communicator/step_debug_ssh_keys.go
@@ -6,7 +6,7 @@ package communicator
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
@@ -24,7 +24,7 @@ func (s *StepDumpSSHKey) Run(_ context.Context, state multistep.StateBag) multis
 
 	ui.Message(fmt.Sprintf("Saving key for debug purposes: %s", s.Path))
 
-	err := ioutil.WriteFile(s.Path, s.SSH.SSHPrivateKey, 0700)
+	err := os.WriteFile(s.Path, s.SSH.SSHPrivateKey, 0700)
 	if err != nil {
 		state.Put("error", fmt.Errorf("Error saving debug key: %s", err))
 		return multistep.ActionHalt

--- a/multistep/basic_runner_test.go
+++ b/multistep/basic_runner_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestBasicRunner_ImplRunner(t *testing.T) {
-	var raw interface{}
-	raw = &BasicRunner{}
+	var raw interface{} = &BasicRunner{}
 	if _, ok := raw.(Runner); !ok {
 		t.Fatalf("BasicRunner must be a Runner")
 	}

--- a/multistep/commonsteps/step_create_cdrom.go
+++ b/multistep/commonsteps/step_create_cdrom.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -316,7 +315,7 @@ func (s *StepCreateCD) AddContent(dst, path, content string) error {
 	if err != nil {
 		return fmt.Errorf("error creating new directory %s: %s", dstDir, err)
 	}
-	err = ioutil.WriteFile(dstPath, []byte(content), 0666)
+	err = os.WriteFile(dstPath, []byte(content), 0666)
 	if err != nil {
 		return fmt.Errorf("Error writing file %s on CD: %s", path, err)
 	}

--- a/multistep/commonsteps/step_create_cdrom_test.go
+++ b/multistep/commonsteps/step_create_cdrom_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,8 +16,7 @@ import (
 )
 
 func TestStepCreateCD_Impl(t *testing.T) {
-	var raw interface{}
-	raw = new(StepCreateCD)
+	var raw interface{} = new(StepCreateCD)
 	if _, ok := raw.(multistep.Step); !ok {
 		t.Fatalf("StepCreateCD should be a step")
 	}
@@ -40,7 +38,7 @@ func createFiles(t *testing.T, rootFolder string, expected map[string]string) {
 		if err != nil {
 			t.Fatalf("mkdir -p: %s", err)
 		}
-		err = ioutil.WriteFile(path, []byte(content), 0666)
+		err = os.WriteFile(path, []byte(content), 0666)
 		if err != nil {
 			t.Fatalf("writing file: %s", err)
 		}
@@ -61,7 +59,7 @@ func checkFiles(t *testing.T, rootFolder string, expected map[string]string) {
 				t.Fatalf("unexpected file: %s", nameSlashSafe)
 			}
 
-			content, err := ioutil.ReadFile(path)
+			content, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatalf("reading file: %s", err)
 			}
@@ -89,7 +87,7 @@ func TestStepCreateCD(t *testing.T) {
 	state := testStepCreateCDState(t)
 	step := new(StepCreateCD)
 
-	dir, err := ioutil.TempDir("", "packer")
+	dir, err := os.MkdirTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -172,7 +170,7 @@ func TestStepCreateCD_missing(t *testing.T) {
 	state := testStepCreateCDState(t)
 	step := new(StepCreateCD)
 
-	dir, err := ioutil.TempDir("", "packer")
+	dir, err := os.MkdirTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/multistep/commonsteps/step_create_floppy.go
+++ b/multistep/commonsteps/step_create_floppy.go
@@ -139,8 +139,7 @@ func (s *StepCreateFloppy) Run(ctx context.Context, state multistep.StateBag) mu
 	crawlDirectoryFiles = []string{}
 
 	// Collect files and copy them flatly...because floppy_files is broken on purpose.
-	var filelist chan string
-	filelist = make(chan string)
+	var filelist = make(chan string)
 	go globFiles(s.Files, filelist)
 
 	ui.Message("Copying files flatly from floppy_files")
@@ -394,9 +393,7 @@ func removeBase(base string, path string) (string, error) {
 type directoryCache func(string) (fs.Directory, error)
 
 func fsDirectoryCache(rootDirectory fs.Directory) directoryCache {
-	var cache map[string]fs.Directory
-
-	cache = make(map[string]fs.Directory)
+	var cache = make(map[string]fs.Directory)
 	cache[""] = rootDirectory
 
 	Input, Output, Error := make(chan string), make(chan fs.Directory), make(chan error)

--- a/multistep/commonsteps/step_create_floppy_test.go
+++ b/multistep/commonsteps/step_create_floppy_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -22,8 +21,7 @@ import (
 const TestFixtures = "test-fixtures"
 
 func TestStepCreateFloppy_Impl(t *testing.T) {
-	var raw interface{}
-	raw = new(StepCreateFloppy)
+	var raw interface{} = new(StepCreateFloppy)
 	if _, ok := raw.(multistep.Step); !ok {
 		t.Fatalf("StepCreateFloppy should be a step")
 	}
@@ -42,7 +40,7 @@ func TestStepCreateFloppy(t *testing.T) {
 	state := testStepCreateFloppyState(t)
 	step := new(StepCreateFloppy)
 
-	dir, err := ioutil.TempDir("", "packer")
+	dir, err := os.MkdirTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -105,7 +103,7 @@ func TestStepCreateFloppy_missing(t *testing.T) {
 	state := testStepCreateFloppyState(t)
 	step := new(StepCreateFloppy)
 
-	dir, err := ioutil.TempDir("", "packer")
+	dir, err := os.MkdirTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -150,7 +148,7 @@ func TestStepCreateFloppy_notfound(t *testing.T) {
 	state := testStepCreateFloppyState(t)
 	step := new(StepCreateFloppy)
 
-	dir, err := ioutil.TempDir("", "packer")
+	dir, err := os.MkdirTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/multistep/commonsteps/step_download_test.go
+++ b/multistep/commonsteps/step_download_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -326,7 +325,7 @@ func createTempDir(t *testing.T) string {
 }
 
 func listFiles(t *testing.T, dir string) []string {
-	fs, err := ioutil.ReadDir(dir)
+	fs, err := os.ReadDir(dir)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/multistep/commonsteps/step_http_server_test.go
+++ b/multistep/commonsteps/step_http_server_test.go
@@ -6,7 +6,7 @@ package commonsteps
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"testing"
@@ -73,7 +73,7 @@ func TestStepHTTPServer_Run(t *testing.T) {
 				if err != nil {
 					t.Fatalf("http.Get: %v", err)
 				}
-				b, err := ioutil.ReadAll(resp.Body)
+				b, err := io.ReadAll(resp.Body)
 				if err != nil {
 					t.Fatalf("readall: %v", err)
 				}

--- a/multistep/commonsteps/step_output_dir_test.go
+++ b/multistep/commonsteps/step_output_dir_test.go
@@ -6,7 +6,6 @@ package commonsteps
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -25,7 +24,7 @@ func testState(t *testing.T) multistep.StateBag {
 }
 
 func testStepOutputDir(t *testing.T) *StepOutputDir {
-	td, err := ioutil.TempDir("", "packer")
+	td, err := os.MkdirTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/multistep/commonsteps/step_provision_test.go
+++ b/multistep/commonsteps/step_provision_test.go
@@ -29,8 +29,7 @@ func testCommConfig() *communicator.Config {
 }
 
 func TestStepProvision_Impl(t *testing.T) {
-	var raw interface{}
-	raw = new(StepProvision)
+	var raw interface{} = new(StepProvision)
 	if _, ok := raw.(multistep.Step); !ok {
 		t.Fatalf("provision should be a step")
 	}

--- a/multistep/debug_runner_test.go
+++ b/multistep/debug_runner_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestDebugRunner_Impl(t *testing.T) {
-	var raw interface{}
-	raw = &DebugRunner{}
+	var raw interface{} = &DebugRunner{}
 	if _, ok := raw.(Runner); !ok {
 		t.Fatal("DebugRunner must be a runner.")
 	}

--- a/multistep/statebag_test.go
+++ b/multistep/statebag_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestBasicStateBag_ImplRunner(t *testing.T) {
-	var raw interface{}
-	raw = &BasicStateBag{}
+	var raw interface{} = &BasicStateBag{}
 	if _, ok := raw.(StateBag); !ok {
 		t.Fatalf("must be a StateBag")
 	}

--- a/packer/cache_config_unix_test.go
+++ b/packer/cache_config_unix_test.go
@@ -7,7 +7,6 @@
 package packer
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,12 +14,12 @@ import (
 
 func TestCachePath(t *testing.T) {
 	// temporary directories for env vars
-	xdgCacheHomeTempDir, err := ioutil.TempDir(os.TempDir(), "*")
+	xdgCacheHomeTempDir, err := os.MkdirTemp(os.TempDir(), "*")
 	if err != nil {
 		t.Fatalf("Failed to create temp test directory: failing test: %v", err)
 	}
 	defer os.RemoveAll(xdgCacheHomeTempDir)
-	packerCacheTempDir, err := ioutil.TempDir(os.TempDir(), "*")
+	packerCacheTempDir, err := os.MkdirTemp(os.TempDir(), "*")
 	if err != nil {
 		t.Fatalf("Failed to create temp test directory: failing test: %v", err)
 	}

--- a/packer/communicator_mock_test.go
+++ b/packer/communicator_mock_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestMockCommunicator_impl(t *testing.T) {
-	var raw interface{}
-	raw = new(MockCommunicator)
+	var raw interface{} = new(MockCommunicator)
 	if _, ok := raw.(Communicator); !ok {
 		t.Fatal("should be a communicator")
 	}

--- a/packer/multi_error_test.go
+++ b/packer/multi_error_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestMultiError_Impl(t *testing.T) {
-	var raw interface{}
-	raw = &MultiError{}
+	var raw interface{} = &MultiError{}
 	if _, ok := raw.(error); !ok {
 		t.Fatal("MultiError must implement error")
 	}

--- a/packer/ui_mock.go
+++ b/packer/ui_mock.go
@@ -6,7 +6,6 @@ package packer
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"testing"
 	"time"
 )
@@ -17,8 +16,8 @@ func TestUi(t *testing.T) Ui {
 	var buf bytes.Buffer
 	return &BasicUi{
 		Reader:      &buf,
-		Writer:      ioutil.Discard,
-		ErrorWriter: ioutil.Discard,
+		Writer:      io.Discard,
+		ErrorWriter: io.Discard,
 		PB:          &NoopProgressTracker{},
 	}
 }

--- a/pathing/config_file_unix_test.go
+++ b/pathing/config_file_unix_test.go
@@ -7,7 +7,6 @@
 package pathing
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,25 +14,25 @@ import (
 
 func TestConfigPath(t *testing.T) {
 	// temporary directories for env vars
-	xdgConfigHomeTempDir, err := ioutil.TempDir(os.TempDir(), "*")
+	xdgConfigHomeTempDir, err := os.MkdirTemp(os.TempDir(), "*")
 	if err != nil {
 		t.Fatalf("Failed to create temp test directory: failing test: %v", err)
 	}
 	defer os.RemoveAll(xdgConfigHomeTempDir)
 
-	packerConfigTempDir, err := ioutil.TempDir(os.TempDir(), "*")
+	packerConfigTempDir, err := os.MkdirTemp(os.TempDir(), "*")
 	if err != nil {
 		t.Fatalf("Failed to create temp test directory: failing test: %v", err)
 	}
 	defer os.RemoveAll(packerConfigTempDir)
 
-	homeTempDir, err := ioutil.TempDir(os.TempDir(), "*")
+	homeTempDir, err := os.MkdirTemp(os.TempDir(), "*")
 	if err != nil {
 		t.Fatalf("Failed to create temp test directory: failing test: %v", err)
 	}
 	defer os.RemoveAll(homeTempDir)
 
-	homeDirDefaultConfigTempDir, err := ioutil.TempDir(os.TempDir(), "*")
+	homeDirDefaultConfigTempDir, err := os.MkdirTemp(os.TempDir(), "*")
 	if err != nil {
 		t.Fatalf("Failed to create temp test directory: failing test: %v", err)
 	}

--- a/rpc/builder.go
+++ b/rpc/builder.go
@@ -126,7 +126,10 @@ func (b *BuilderServer) Run(streamId uint32, reply *uint32) error {
 	if artifact != nil {
 		streamId = b.mux.NextId()
 		artifactServer := newServerWithMux(b.mux, streamId)
-		artifactServer.RegisterArtifact(artifact)
+		err := artifactServer.RegisterArtifact(artifact)
+		if err != nil {
+			return err
+		}
 		go artifactServer.Serve()
 		*reply = streamId
 	}

--- a/rpc/communicator_test.go
+++ b/rpc/communicator_test.go
@@ -164,8 +164,7 @@ func TestCommunicatorRPC(t *testing.T) {
 }
 
 func TestCommunicator_ImplementsCommunicator(t *testing.T) {
-	var raw interface{}
-	raw = Communicator(nil)
+	var raw interface{} = Communicator(nil)
 	if _, ok := raw.(packersdk.Communicator); !ok {
 		t.Fatal("should be a Communicator")
 	}

--- a/rpc/datasource_test.go
+++ b/rpc/datasource_test.go
@@ -83,8 +83,7 @@ func TestDatasource(t *testing.T) {
 }
 
 func TestDatasource_Implements(t *testing.T) {
-	var raw interface{}
-	raw = new(datasource)
+	var raw interface{} = new(datasource)
 	if _, ok := raw.(packer.Datasource); !ok {
 		t.Fatal("not a datasource")
 	}

--- a/rpc/post_processor_test.go
+++ b/rpc/post_processor_test.go
@@ -134,8 +134,7 @@ func TestPostProcessorRPC_cancel(t *testing.T) {
 }
 
 func TestPostProcessor_Implements(t *testing.T) {
-	var raw interface{}
-	raw = new(postProcessor)
+	var raw interface{} = new(postProcessor)
 	if _, ok := raw.(packersdk.PostProcessor); !ok {
 		t.Fatal("not a postprocessor")
 	}

--- a/rpc/ui_test.go
+++ b/rpc/ui_test.go
@@ -6,7 +6,6 @@ package rpc
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"testing"
 )
@@ -122,7 +121,7 @@ func TestUiRPC(t *testing.T) {
 	}
 
 	ctt := []byte("foo bar baz !!!")
-	rc := ioutil.NopCloser(bytes.NewReader(ctt))
+	rc := io.NopCloser(bytes.NewReader(ctt))
 
 	stream := uiClient.TrackProgress("stuff.txt", 0, int64(len(ctt)), rc)
 	if ui.trackProgressCalled != true {

--- a/sdk-internals/communicator/none/communicator_test.go
+++ b/sdk-internals/communicator/none/communicator_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestCommIsCommunicator(t *testing.T) {
-	var raw interface{}
-	raw = &comm{}
+	var raw interface{} = &comm{}
 	if _, ok := raw.(packersdk.Communicator); !ok {
 		t.Fatalf("comm must be a communicator")
 	}

--- a/sdk-internals/communicator/ssh/communicator.go
+++ b/sdk-internals/communicator/ssh/communicator.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -715,7 +714,7 @@ func (c *comm) scpDownloadSession(path string, output io.Writer) error {
 			return err
 		}
 
-		if len(fi) < 0 {
+		if len(fi) == 0 {
 			return fmt.Errorf("empty response from server")
 		}
 
@@ -821,7 +820,7 @@ func (c *comm) scpSession(scpCommand string, f func(io.Writer, *bufio.Reader) er
 			// Otherwise, we have an ExitError, meaning we can just read the
 			// exit status
 			log.Printf("[DEBUG] non-zero exit status: %d, %v", exitErr.ExitStatus(), err)
-			stdoutB, err := ioutil.ReadAll(stdoutR)
+			stdoutB, err := io.ReadAll(stdoutR)
 			if err != nil {
 				return err
 			}

--- a/sdk-internals/communicator/ssh/communicator_test.go
+++ b/sdk-internals/communicator/ssh/communicator_test.go
@@ -124,8 +124,7 @@ func newMockBrokenServer(t *testing.T) string {
 }
 
 func TestCommIsCommunicator(t *testing.T) {
-	var raw interface{}
-	raw = &comm{}
+	var raw interface{} = &comm{}
 	if _, ok := raw.(packersdk.Communicator); !ok {
 		t.Fatalf("comm must be a communicator")
 	}

--- a/sdk-internals/communicator/ssh/keyboard_interactive.go
+++ b/sdk-internals/communicator/ssh/keyboard_interactive.go
@@ -4,15 +4,15 @@
 package ssh
 
 import (
+	"golang.org/x/term"
 	"io"
 	"log"
 
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 func KeyboardInteractive(c io.ReadWriter) ssh.KeyboardInteractiveChallenge {
-	t := terminal.NewTerminal(c, "")
+	t := term.NewTerminal(c, "")
 	return func(user, instruction string, questions []string, echos []bool) ([]string, error) {
 		if len(questions) == 0 {
 			return []string{}, nil
@@ -29,7 +29,7 @@ func KeyboardInteractive(c io.ReadWriter) ssh.KeyboardInteractiveChallenge {
 			if err != nil {
 				return nil, err
 			}
-			answers[i] = string(s)
+			answers[i] = s
 		}
 		return answers, nil
 	}

--- a/sdk-internals/communicator/ssh/password_test.go
+++ b/sdk-internals/communicator/ssh/password_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestPasswordKeyboardInteractive_Impl(t *testing.T) {
-	var raw interface{}
-	raw = PasswordKeyboardInteractive("foo")
+	var raw interface{} = PasswordKeyboardInteractive("foo")
 	if _, ok := raw.(ssh.KeyboardInteractiveChallenge); !ok {
 		t.Fatal("PasswordKeyboardInteractive must implement KeyboardInteractiveChallenge")
 	}

--- a/sdk-internals/communicator/winrm/communicator.go
+++ b/sdk-internals/communicator/winrm/communicator.go
@@ -11,7 +11,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -170,7 +169,7 @@ func (c *Communicator) Download(src string, dst io.Writer) error {
 	base64DecodePipe := &Base64Pipe{w: dst}
 
 	cmd := winrm.Powershell(fmt.Sprintf(encodeScript, src))
-	_, err = client.Run(cmd, base64DecodePipe, ioutil.Discard)
+	_, err = client.Run(cmd, base64DecodePipe, io.Discard)
 
 	return err
 }
@@ -235,7 +234,7 @@ type Base64Pipe struct {
 }
 
 func (d *Base64Pipe) ReadFrom(r io.Reader) (int64, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return 0, err
 	}

--- a/tmp/tmp.go
+++ b/tmp/tmp.go
@@ -17,7 +17,6 @@
 package tmp
 
 import (
-	"io/ioutil"
 	"os"
 )
 
@@ -31,7 +30,7 @@ var tmpDir = os.TempDir()
 // It is the caller's responsibility
 // to remove the file when no longer needed.
 func Dir(prefix string) (string, error) {
-	return ioutil.TempDir(tmpDir, prefix)
+	return os.MkdirTemp(tmpDir, prefix)
 }
 
 // File creates a new temporary file in the system temporary
@@ -45,5 +44,5 @@ func Dir(prefix string) (string, error) {
 // to find the pathname of the file. It is the caller's responsibility
 // to remove the file when no longer needed.
 func File(pattern string) (*os.File, error) {
-	return ioutil.TempFile(tmpDir, pattern)
+	return os.CreateTemp(tmpDir, pattern)
 }


### PR DESCRIPTION
Remove the ioutil package as suggested by the linter in favour of the io and os packages. Also fixes other linting warnings.