### PR TITLE
shell-local: fix supported_os error check

### DIFF
--- a/shell-local/config.go
+++ b/shell-local/config.go
@@ -150,7 +150,7 @@ func Validate(config *Config) error {
 					break
 				}
 			}
-			if supported_os {
+			if !supported_os {
 				return fmt.Errorf("Invalid OS specified in only_on: '%s'\n"+
 					"Supported OS names: %s", provided_os, strings.Join(supportedSyslist, ", "))
 			}


### PR DESCRIPTION
Commit 34ed5d9031 which consists of linting fixes essentially had an error in the code and the error check for `supported_os' was inverted in this commit, making shell-local fail on all supported OSes now.

We re-invert this condition so it behaves as it used to.