### PR TITLE
ssh: add warnings on DSA usage

### DIFF
--- a/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/SSHTemporaryKeyPair-not-required.mdx
+++ b/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/SSHTemporaryKeyPair-not-required.mdx
@@ -4,6 +4,9 @@
   
   Specifies the type of key to create. The possible values are 'dsa',
   'ecdsa', 'ed25519', or 'rsa'.
+  
+  NOTE: DSA is deprecated and no longer recognized as secure, please
+  consider other alternatives like RSA or ED25519.
 
 - `temporary_key_pair_bits` (int) - Specifies the number of bits in the key to create. For RSA keys, the
   minimum size is 1024 bits and the default is 4096 bits. Generally, 3072
@@ -13,5 +16,8 @@
   bits. Attempting to use bit lengths other than these three values for
   ECDSA keys will fail. Ed25519 keys have a fixed length and bits will be
   ignored.
+  
+  NOTE: DSA is deprecated and no longer recognized as secure as specified
+  by FIPS 186-5, please consider other alternatives like RSA or ED25519.
 
 <!-- End of code generated from the comments of the SSHTemporaryKeyPair struct in communicator/config.go; -->

--- a/communicator/config.go
+++ b/communicator/config.go
@@ -207,6 +207,9 @@ type SSHTemporaryKeyPair struct {
 	//
 	// Specifies the type of key to create. The possible values are 'dsa',
 	// 'ecdsa', 'ed25519', or 'rsa'.
+	//
+	// NOTE: DSA is deprecated and no longer recognized as secure, please
+	// consider other alternatives like RSA or ED25519.
 	SSHTemporaryKeyPairType string `mapstructure:"temporary_key_pair_type"`
 	// Specifies the number of bits in the key to create. For RSA keys, the
 	// minimum size is 1024 bits and the default is 4096 bits. Generally, 3072
@@ -216,6 +219,9 @@ type SSHTemporaryKeyPair struct {
 	// bits. Attempting to use bit lengths other than these three values for
 	// ECDSA keys will fail. Ed25519 keys have a fixed length and bits will be
 	// ignored.
+	//
+	// NOTE: DSA is deprecated and no longer recognized as secure as specified
+	// by FIPS 186-5, please consider other alternatives like RSA or ED25519.
 	SSHTemporaryKeyPairBits int `mapstructure:"temporary_key_pair_bits"`
 }
 


### PR DESCRIPTION
The DSA signature algorithm is not considered secure anymore, and is actively deprecated in the Go crypto libs (SEE https://pkg.go.dev/crypto/dsa).

To let users know that they should not use that anymore, we add a notice in the comments for the SSH private key options.

This is linked to PR #153, where the imports for the DSA package were annotated as `nolint` as importing them triggers lint warnings.