### PR TITLE
ssh: use sftp by default for transferring files

### DIFF
--- a/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/SSH-not-required.mdx
+++ b/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/SSH-not-required.mdx
@@ -72,13 +72,13 @@
   The `~` can be used in path and will be expanded to the
   home directory of current user.
 
-- `ssh_file_transfer_method` (string) - `scp` or `sftp` - How to transfer files, Secure copy (default) or SSH
-  File Transfer Protocol.
+- `ssh_file_transfer_method` (string) - `scp` or `sftp` - How to transfer files, Secure copy or SSH File Transfer
+  Protocol (default).
   
   **NOTE**: Guests using Windows with Win32-OpenSSH v9.1.0.0p1-Beta, scp
-  (the default protocol for copying data) returns a a non-zero error code since the MOTW
-  cannot be set, which cause any file transfer to fail. As a workaround you can override the transfer protocol
-  with SFTP instead `ssh_file_transfer_protocol = "sftp"`.
+  returns a a non-zero error code since the MOTW cannot be set, which causes
+  any file transfer to fail. As a workaround you can override the transfer
+  protocol with SFTP instead `ssh_file_transfer_protocol = "sftp"`.
 
 - `ssh_proxy_host` (string) - A SOCKS proxy host to use for SSH connection
 

--- a/communicator/config.go
+++ b/communicator/config.go
@@ -163,13 +163,13 @@ type SSH struct {
 	// The `~` can be used in path and will be expanded to the
 	//home directory of current user.
 	SSHBastionCertificateFile string `mapstructure:"ssh_bastion_certificate_file"`
-	// `scp` or `sftp` - How to transfer files, Secure copy (default) or SSH
-	// File Transfer Protocol.
+	// `scp` or `sftp` - How to transfer files, Secure copy or SSH File Transfer
+	// Protocol (default).
 	//
 	// **NOTE**: Guests using Windows with Win32-OpenSSH v9.1.0.0p1-Beta, scp
-	// (the default protocol for copying data) returns a a non-zero error code since the MOTW
-	// cannot be set, which cause any file transfer to fail. As a workaround you can override the transfer protocol
-	// with SFTP instead `ssh_file_transfer_protocol = "sftp"`.
+	// returns a a non-zero error code since the MOTW cannot be set, which causes
+	// any file transfer to fail. As a workaround you can override the transfer
+	// protocol with SFTP instead `ssh_file_transfer_protocol = "sftp"`.
 	SSHFileTransferMethod string `mapstructure:"ssh_file_transfer_method"`
 	// A SOCKS proxy host to use for SSH connection
 	SSHProxyHost string `mapstructure:"ssh_proxy_host"`
@@ -513,7 +513,7 @@ func (c *Config) prepareSSH(ctx *interpolate.Context) []error {
 	}
 
 	if c.SSHFileTransferMethod == "" {
-		c.SSHFileTransferMethod = "scp"
+		c.SSHFileTransferMethod = "sftp"
 	}
 
 	// Backwards compatibility


### PR DESCRIPTION
Recently Windows's SSH server implementation has changed the way they set the MOTW on the receiving end for file transfers, which coupled with the way Packer invokes the command, causes the transfers to fail since the command exits with a non-zero error code.

While this is going to be fixed in an upcoming release, we are changing the default method for transferring data from the host to the guest from scp to sftp.

This is motivated in part by the aforementioned problem with Windows's SSH server, but also by a decision on the OpenSSH part, where with version 9, they also decided to not use scp the protocol for sending/receiving files, and even when using the `scp' client, the protocol would default to sftp.

Given both decisions, coupled with the fact that scp is insecure and obsolete, we change the default method for transferring files between endpoints to sftp by default.