### PR TITLE
GHA migration finalisation

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,13 @@
+name: Lint GitHub Actions Workflows
+on:
+  push:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+      - name: "Check workflow files"
+        uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint:latest

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -59,10 +59,10 @@ jobs:
 
       - name: Run Go tests
         run: |
-          PACKAGE_NAMES=$(go list ./...)
-          echo "Running $(echo $PACKAGE_NAMES | wc -w) packages"
-          echo $PACKAGE_NAMES
-          gotestsum --format=short-verbose --junitfile $TEST_RESULTS_PATH/packer-plugin-sdk/gotestsum-report.xml -- -p 2 $PACKAGE_NAMES
+          PACKAGE_NAMES="$(go list ./...)"
+          echo "Running $(echo "$PACKAGE_NAMES" | wc -w) packages"
+          echo "$PACKAGE_NAMES"
+          echo "$PACKAGE_NAMES" | xargs -I {} gotestsum --format=short-verbose --junitfile "$TEST_RESULTS_PATH"/packer-plugin-sdk/gotestsum-report.xml -- -count 1 -p 2 {};
 
       # Save coverage report parts
       - name: Upload and save artifacts
@@ -111,10 +111,10 @@ jobs:
       - name: Run Go tests
         shell: bash
         run: |
-          PACKAGE_NAMES=$(go list ./...)
-          echo "Running $(echo $PACKAGE_NAMES | wc -w) packages"
-          echo $PACKAGE_NAMES
-          gotestsum --format=short-verbose --junitfile $TEST_RESULTS_PATH/packer-plugin-sdk/gotestsum-report.xml -- -p 2 $PACKAGE_NAMES
+          PACKAGE_NAMES="$(go list ./...)"
+          echo "Running $(echo "$PACKAGE_NAMES" | wc -w) packages"
+          echo "$PACKAGE_NAMES"
+          echo "$PACKAGE_NAMES" | xargs -I {} gotestsum --format=short-verbose --junitfile "$TEST_RESULTS_PATH"/packer-plugin-sdk/gotestsum-report.xml -- -count 1 -p 2 {};
       
       # Save coverage report parts
       - name: Upload and save artifacts
@@ -163,10 +163,10 @@ jobs:
 
       - name: Run Go tests
         run: |
-          PACKAGE_NAMES=$(go list ./...)
-          echo "Running $(echo $PACKAGE_NAMES | wc -w) packages"
-          echo $PACKAGE_NAMES
-          gotestsum --format=short-verbose --junitfile $TEST_RESULTS_PATH/packer-plugin-sdk/gotestsum-report.xml -- -p 2 $PACKAGE_NAMES
+          PACKAGE_NAMES="$(go list ./...)"
+          echo "Running $(echo "$PACKAGE_NAMES" | wc -w) packages"
+          echo "$PACKAGE_NAMES"
+          echo "$PACKAGE_NAMES" | xargs -I {} gotestsum --format=short-verbose --junitfile "$TEST_RESULTS_PATH"/packer-plugin-sdk/gotestsum-report.xml -- -count 1 -p 2 {};
 
       # Save coverage report parts
       - name: Upload and save artifacts

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -25,19 +25,19 @@ jobs:
       contents: read
     steps:
       - name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: ${{ matrix.go-version }}
       
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
 
       - name: Create test directory
         run: |
           mkdir -p ${{ env.TEST_RESULTS_PATH }}/packer-plugin-sdk
   
       - name: Setup cache for go modules
-        uses: actions/cache@v3
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: |
             ~/.cache/go-build
@@ -69,7 +69,7 @@ jobs:
 
       # Save coverage report parts
       - name: Upload and save artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: linux test results
           path: ${{ env.TEST_RESULTS_PATH }}
@@ -88,15 +88,15 @@ jobs:
         run: git config --global core.autocrlf false
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
 
       - name: Setup cache for go modules
-        uses: actions/cache@v3
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: |
             ~\AppData\Local\go-build
@@ -121,7 +121,7 @@ jobs:
       
       # Save coverage report parts
       - name: Upload and save artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: windows test results
           path: ${{ env.TEST_RESULTS_PATH }}
@@ -137,19 +137,19 @@ jobs:
       contents: read
     steps:
       - name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
 
       - name: Create test directory
         run: |
           mkdir -p ${{ env.TEST_RESULTS_PATH }}/packer-plugin-sdk
 
       - name: Setup cache for go modules
-        uses: actions/cache@v3
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: |
             ~/.cache/go-build
@@ -173,7 +173,7 @@ jobs:
 
       # Save coverage report parts
       - name: Upload and save artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: macos test results
           path: ${{ env.TEST_RESULTS_PATH }}

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,5 +1,4 @@
 name: go-test
-
 on: 
   push:
     branches:
@@ -7,13 +6,11 @@ on:
   pull_request:
     branches:
       - main
-
-
 env:
   TEST_RESULTS_PATH: /tmp/test-results
-
+permissions:
+  contents: read
 jobs:
-
   linux-tests:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b # v4.2.0
         with: 
           args: "release"
         env:


### PR DESCRIPTION
As part of the ongoing efforts to migrate from Circle CI to GHA, this PR pins the external actions to a SHA, adds actionlint to the repo, and fixes permissions for actions that didn't have it yet.