### PR TITLE
communicator: don't set bastion cert if key is set

### DIFF
--- a/communicator/config.go
+++ b/communicator/config.go
@@ -496,6 +496,16 @@ func (c *Config) prepareSSH(ctx *interpolate.Context) []error {
 		c.SSHKeepAliveInterval = 5 * time.Second
 	}
 
+	// Validation
+	var errs []error
+	if c.SSHPrivateKeyFile == "" && c.SSHCertificateFile != "" {
+		errs = append(errs, fmt.Errorf("ssh_private_key_file must be specified if ssh_certificate_file is specified"))
+	}
+
+	if c.SSHBastionPrivateKeyFile == "" && c.SSHBastionCertificateFile != "" {
+		errs = append(errs, fmt.Errorf("ssh_bastion_private_key_file must be specified if ssh_bastion_certificate_file is specified"))
+	}
+
 	if c.SSHBastionHost != "" {
 		if c.SSHBastionPort == 0 {
 			c.SSHBastionPort = 22
@@ -503,12 +513,8 @@ func (c *Config) prepareSSH(ctx *interpolate.Context) []error {
 
 		if c.SSHBastionPrivateKeyFile == "" && c.SSHPrivateKeyFile != "" {
 			c.SSHBastionPrivateKeyFile = c.SSHPrivateKeyFile
-		}
-
-		if c.SSHBastionCertificateFile == "" && c.SSHCertificateFile != "" {
 			c.SSHBastionCertificateFile = c.SSHCertificateFile
 		}
-
 	}
 
 	if c.SSHProxyHost != "" {
@@ -526,8 +532,6 @@ func (c *Config) prepareSSH(ctx *interpolate.Context) []error {
 		c.SSHTimeout = c.SSHWaitTimeout
 	}
 
-	// Validation
-	var errs []error
 	if c.SSHUsername == "" {
 		errs = append(errs, errors.New("An ssh_username must be specified\n  Note: some builders used to default ssh_username to \"root\"."))
 	}


### PR DESCRIPTION
When attempting to set the bastion key/certificate for authenticating with the bastion, we generally fallback to the ones defined by the SSH configuration.

However, if the bastion SSH key is set, and not the certificate, but the SSH connection's are, since the conditions are separate, we end-up in a situation where the bastion's SSH key uses the one from the config, and the certificate fall backs to the one from the SSH connection.

This in turn fails, as the certificate's public key matches the private key from the SSH connection, and not the bastion's.

To avoid a situation like this, we only fallback to the SSH connection's certificate if the bastion's SSH key isn't set.

Closes #173 
