### PR TITLE
[HPR-1100] Add basic test for commonServer.ConfigSpec

### DIFF
--- a/rpc/common.go
+++ b/rpc/common.go
@@ -14,7 +14,7 @@ import (
 )
 
 // commonClient allows to rpc call funcs that can be defined on the different
-// build blocks of packer
+// build blocks of Packer.
 type commonClient struct {
 	// endpoint is usually the type of build block we are connecting to.
 	//
@@ -25,7 +25,8 @@ type commonClient struct {
 }
 
 type commonServer struct {
-	mux              *muxBroker
+	mux *muxBroker
+	// a HCL2 enabled component such as a Builder
 	selfConfigurable interface {
 		ConfigSpec() hcldec.ObjectSpec
 	}

--- a/rpc/common_test.go
+++ b/rpc/common_test.go
@@ -7,8 +7,6 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 )
 
-var b testing.B
-
 func TestCommonServer_ConfigSpec(t *testing.T) {
 	tt := []struct {
 		name      string

--- a/rpc/common_test.go
+++ b/rpc/common_test.go
@@ -1,0 +1,68 @@
+package rpc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2/hcldec"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+var b testing.B
+
+func TestCommonServer_ConfigSpec(t *testing.T) {
+	tt := []struct {
+		name      string
+		component packersdk.HCL2Speccer
+	}{
+		{
+			name:      "Builder Component Server",
+			component: new(packersdk.MockBuilder),
+		},
+		{
+			name:      "Datasource Component Server",
+			component: new(packersdk.MockDatasource),
+		},
+		{
+			name:      "Provisioner Component Server",
+			component: new(packersdk.MockProvisioner),
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Start the server
+			client, server := testClientServer(t)
+			defer client.Close()
+			defer server.Close()
+
+			var spec hcldec.ObjectSpec
+			switch v := tc.component.(type) {
+			case packersdk.Builder:
+				server.RegisterBuilder(v)
+				remote := client.Builder()
+				spec = remote.ConfigSpec()
+			case packersdk.Datasource:
+				server.RegisterDatasource(v)
+				remote := client.Datasource()
+				spec = remote.ConfigSpec()
+			case packersdk.Provisioner:
+				server.RegisterProvisioner(v)
+				remote := client.Provisioner()
+				spec = remote.ConfigSpec()
+			case packersdk.PostProcessor:
+				server.RegisterPostProcessor(v)
+				remote := client.PostProcessor()
+				spec = remote.ConfigSpec()
+			default:
+				t.Fatalf("Unknown component type %T", v)
+			}
+
+			if len(spec) == 0 {
+				t.Errorf("expected remote.ConfigSpec for %T to return a valid hcldec.ObjectSpec, but return %v", tc.component, spec)
+			}
+
+		})
+	}
+
+}

--- a/rpc/datasource_test.go
+++ b/rpc/datasource_test.go
@@ -66,6 +66,12 @@ func TestDatasource(t *testing.T) {
 	d.outputSpec = map[string]hcldec.Spec{
 		"foo": &hcldec.AttrSpec{Name: "foo", Type: cty.String, Required: false},
 	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Call to ConfigSpec for datasource panicked: %v", r)
+		}
+	}()
 	spec := dsClient.OutputSpec()
 	if !reflect.DeepEqual(spec, d.outputSpec) {
 		t.Fatalf("unknown outputSpec value: %#v", spec)


### PR DESCRIPTION
The Packer SDK relies on encoding/gob for serializing hcldec.ObjectSpec over RPC. The added test check that types implementing the HCL2Speccer interface can be encoded/decoded without issue.

Starting in go-cty v1.11.0 support for encoding/gob was removed, which causes the added tests to fail. This is expected and is meant to help catch potential regressions moving forward.

Test results running go-cty v1.10.0

    --- PASS: TestCommonServer_ConfigSpec (0.00s)
        --- PASS: TestCommonServer_ConfigSpec/Builder_Component_Server (0.00s)
        --- PASS: TestCommonServer_ConfigSpec/Datasource_Component_Server (0.00s)
        --- PASS: TestCommonServer_ConfigSpec/Provisioner_Component_Server (0.00s)
    === RUN   TestCommunicatorRPC


Test results running go-cty v1.13.1
```
~> go get github.com/zclconf/go-cty@v1.13.1
~>  go test ./rpc/... -v -run=TestCommonServer
=== RUN   TestCommonServer_ConfigSpec
=== RUN   TestCommonServer_ConfigSpec/Builder_Component_Server
    common_test.go:75: Call to ConfigSpec for Builder Component Server panicked: ConfigSpec failed: gob: type cty.Type has no exported fields
2023/04/21 14:31:27 [WARN] Shutting down mux conn in Server
2023/04/21 14:31:27 [WARN] Client is closing mux
=== RUN   TestCommonServer_ConfigSpec/Datasource_Component_Server
    common_test.go:75: Call to ConfigSpec for Datasource Component Server panicked: ConfigSpec failed: gob: type cty.Type has no exported fields
2023/04/21 14:31:27 [WARN] Shutting down mux conn in Server
2023/04/21 14:31:27 [WARN] Client is closing mux
=== RUN   TestCommonServer_ConfigSpec/Provisioner_Component_Server
    common_test.go:75: Call to ConfigSpec for Provisioner Component Server panicked: ConfigSpec failed: gob: type cty.Type has no exported fields
2023/04/21 14:31:27 [WARN] Shutting down mux conn in Server
2023/04/21 14:31:27 [WARN] Client is closing mux
--- FAIL: TestCommonServer_ConfigSpec (0.00s)
    --- FAIL: TestCommonServer_ConfigSpec/Builder_Component_Server (0.00s)
    --- FAIL: TestCommonServer_ConfigSpec/Datasource_Component_Server (0.00s)
    --- FAIL: TestCommonServer_ConfigSpec/Provisioner_Component_Server (0.00s)
FAIL
FAIL    github.com/hashicorp/packer-plugin-sdk/rpc      0.278s
FAIL
```

Using local fork of zclconf/go-ctyv1.12.1 with `encoding/gob`
```
~>  go test ./rpc/... -v -run=TestCommonServer
=== RUN   TestCommonServer_ConfigSpec
=== RUN   TestCommonServer_ConfigSpec/Builder_Component_Server
2023/04/21 14:59:37 [WARN] Shutting down mux conn in Server
2023/04/21 14:59:37 [WARN] Client is closing mux
=== RUN   TestCommonServer_ConfigSpec/Datasource_Component_Server
2023/04/21 14:59:37 [WARN] Shutting down mux conn in Server
2023/04/21 14:59:37 [WARN] Client is closing mux
=== RUN   TestCommonServer_ConfigSpec/Provisioner_Component_Server
2023/04/21 14:59:37 [WARN] Shutting down mux conn in Server
2023/04/21 14:59:37 [WARN] Client is closing mux
--- PASS: TestCommonServer_ConfigSpec (0.01s)
    --- PASS: TestCommonServer_ConfigSpec/Builder_Component_Server (0.00s)
    --- PASS: TestCommonServer_ConfigSpec/Datasource_Component_Server (0.00s)
    --- PASS: TestCommonServer_ConfigSpec/Provisioner_Component_Server (0.00s)
PASS
ok      github.com/hashicorp/packer-plugin-sdk/rpc      0.321s
```

