### PR TITLE
ssh: add -d option to scp when copying directories

### DIFF
--- a/sdk-internals/communicator/ssh/communicator.go
+++ b/sdk-internals/communicator/ssh/communicator.go
@@ -668,7 +668,7 @@ func (c *comm) scpUploadSession(path string, input io.Reader, fi *os.FileInfo) e
 		return scpUploadFile(target_file, input, w, stdoutR, fi)
 	}
 
-	return c.scpSession("scp -vt "+target_dir, scpFunc)
+	return c.scpSession("scp -vdt "+target_dir, scpFunc)
 }
 
 func (c *comm) scpUploadDirSession(dst string, src string, excl []string) error {


### PR DESCRIPTION
The -d option of scp, as for the -t option, is an undocumented one, and is used for specifying that we are working in directory mode.

In effect, this flag ensures that the target is to be a directory, and implies that scp will check that the target directory exists before attempting to copy the contents of the source.

Adding this flag to the scp sink makes the communicator behave correctly in relation to the scp command as it would be used by clients, rejecting copies to a non-existent destination directory, rather than mistakenly creating it, partially (or completely) copying the source's contents, and potentially succeeding where it should not.