### PR TITLE
[HPR-1108] Add compile time check for go-cty

### DIFF
--- a/rpc/cty_encode.go
+++ b/rpc/cty_encode.go
@@ -4,9 +4,15 @@
 package rpc
 
 import (
+	"encoding/gob"
+
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/json"
 )
+
+// Test that cty types implement the gob.GobEncoder interface.
+// Support for encoding/gob was removed in github.com/zclconf/go-cty@v1.11.0.
+var _ gob.GobEncoder = cty.Value{}
 
 // cty.Value is does not know how to encode itself through the wire so we
 // transform it to bytes.

--- a/rpc/cty_encode.go
+++ b/rpc/cty_encode.go
@@ -4,15 +4,9 @@
 package rpc
 
 import (
-	"encoding/gob"
-
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/json"
 )
-
-// Test that cty types implement the gob.GobEncoder interface.
-// Support for encoding/gob was removed in github.com/zclconf/go-cty@v1.11.0.
-var _ gob.GobEncoder = cty.Value{}
 
 // cty.Value is does not know how to encode itself through the wire so we
 // transform it to bytes.

--- a/rpc/init.go
+++ b/rpc/init.go
@@ -9,7 +9,16 @@ underpins the packer server that all plugins must implement.
 */
 package rpc
 
-import "encoding/gob"
+import (
+	"encoding/gob"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Test that cty types implement the gob.GobEncoder interface.
+// Support for encoding/gob was removed in github.com/zclconf/go-cty@v1.11.0.
+// Refer to issue https://github.com/hashicorp/packer-plugin-sdk/issues/187
+var _ gob.GobEncoder = cty.Value{}
 
 func init() {
 	gob.Register(new(map[string]string))


### PR DESCRIPTION
In v1.11.0, the go-cty package dropped support for encoding/gob. Gob support is used
by the SDK to serialize HCL2 object specs over the wire. If a plugin or Packer upgrades
their version of zclconf/go-cty to one that does not contain Gob support the plugin will build
but crash when trying to run a build on an HCL2 template. By adding this check, a consumer of the SDK
will fail to compile if they are using an unsupported version of go-cty. This check is being added
as a guard to prevent Packer SDK consumers from becoming out of sync with unsupported go-cty versions.

```
~> go get github.com/hashicorp/go-cty v1.13.0
~> make dev
rpc/cty_encode.go:15:24 cannot use cty.Value{} (value of type cty.Value) as type gob.GobEncoder
```

- Related to https://github.com/hashicorp/packer-plugin-sdk/issues/135
- Related to https://github.com/hashicorp/packer/issues/12182

### TODO

- [x] Open Issue for Compile Time Check Workaround - https://github.com/hashicorp/packer-plugin-sdk/issues/187
