### PR TITLE
Remove extra backticks from HTTP server documentation

### DIFF
--- a/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/multistep/commonsteps/HTTPConfig.mdx
+++ b/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/multistep/commonsteps/HTTPConfig.mdx
@@ -6,6 +6,8 @@ referenced will be available in your builder.
 
 Example usage from a builder:
 
-	`wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg`
+```
+wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
+```
 
 <!-- End of code generated from the comments of the HTTPConfig struct in multistep/commonsteps/http_config.go; -->

--- a/multistep/commonsteps/http_config.go
+++ b/multistep/commonsteps/http_config.go
@@ -17,7 +17,9 @@ import (
 //
 // Example usage from a builder:
 //
-//	`wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg`
+// ```
+// wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
+// ```
 type HTTPConfig struct {
 	// Path to a directory to serve using an HTTP server. The files in this
 	// directory will be available over HTTP that will be requestable from the


### PR DESCRIPTION
Problem: HTTP server example usage is shown with backticks [in the documentation](https://developer.hashicorp.com/packer/plugins/builders/tart#http-server-configuration) ([source includes `packer-plugin-sdk/multistep/commonsteps/HTTPConfig.mdx`](https://github.com/cirruslabs/packer-plugin-tart/blob/c5e6e6f40fafb0fc033e5048fd706721d7fe2869/docs/builders/tart.mdx#L61)):

<img width="714" alt="Screenshot 2023-06-26 at 18 45 33" src="https://github.com/hashicorp/packer-plugin-sdk/assets/85709/192fe133-191f-4a3c-bf2b-9f3620cd1997">

Solution: explicitly treat example usage as code.