### PR TITLE
Fix diff header for fix command

### DIFF
--- a/cmd/packer-sdc/internal/fix/cmd.go
+++ b/cmd/packer-sdc/internal/fix/cmd.go
@@ -143,7 +143,7 @@ func processFiles(rootDir string, showDiff bool) error {
 
 	if showDiff {
 		for filename, fixedData := range fixedFiles {
-			diff.Text(filename, filename+"fixed", string(srcFiles[filename]), string(fixedData), os.Stdout)
+			diff.Text(filename, "Fixed: "+filename, string(srcFiles[filename]), string(fixedData), os.Stdout)
 		}
 		return nil
 	}


### PR DESCRIPTION
Old Output
```
~>  ./packer-sdc fix -diff ../../../packer
--- /home/vagrant/Development/packer/go.mod
+++ /home/vagrant/Development/packer/go.mod-fixed
@@ -213,3 +213,5 @@
 )

```

New Output
```
~>  ./packer-sdc fix -diff ../../../packer
--- /home/vagrant/Development/packer/go.mod
+++ Fixed: /home/vagrant/Development/packer/go.mod
@@ -213,3 +213,5 @@
 )

```
