### PR TITLE
packer-sdc: Remove version specific Go code

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.20.3
+          - '1.19'
+          - '1.20'
     permissions:
       id-token: write
       contents: read
@@ -78,7 +79,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.20.3
+          - '1.19'
+          - '1.20'
     permissions:
       id-token: write
       contents: read
@@ -126,7 +128,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.20.3
+          - '1.19'
+          - '1.20'
     permissions:
       id-token: write
       contents: read

--- a/go.mod
+++ b/go.mod
@@ -118,4 +118,4 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 )
 
-go 1.18
+go 1.19


### PR DESCRIPTION
- Remove use of Go 1.20 language features
- Add matrix builds for supported Go versions

Branched from #197 
