### PR TITLE
go.mod: retract v0.5.0

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Check that go.mod does not contain a replace
         run: |
-          if grep -q "replace" <go.mod; then
+          if grep -Eq "^\s*replace" <go.mod; then
             echo "go.mod contains a replace but should not." >&2
             false
           fi

--- a/go.mod
+++ b/go.mod
@@ -119,3 +119,5 @@ require (
 )
 
 go 1.19
+
+retract v0.5.0 // v0.5.0 of the SDK was broken because of the replace statement for go-cty


### PR DESCRIPTION
Since the SDK in v0.5.0 contains a release statement in its go.mod, this makes it impossible to go install packer-sdc from a plugin.

Since those plugins rely on their Makefile to do this, we cannot change them all at once, so we fixed the problem in the SDK code itself, and v0.5.0 is broken, so we retract it in this commit.