### PR TITLE
acctest: add capability to add args to build

### DIFF
--- a/acctest/pluginacc.go
+++ b/acctest/pluginacc.go
@@ -25,6 +25,10 @@ const TestEnvVar = "PACKER_ACC"
 type PluginTestCase struct {
 	// Init, if true `packer init` will be executed prior to `packer build`.
 	Init bool
+	// BuildExtraArgs is the list of arguments to be passed as extra to the packer build
+	// command.
+	// These arguments are injected before the already present `--machine-readable` option.
+	BuildExtraArgs []string
 	// CheckInit is called after packer init step is executed in order to test that
 	// the step executed successfully. If this is not set, then the next
 	// step will be called
@@ -118,8 +122,14 @@ func TestPlugin(t *testing.T, testCase *PluginTestCase) {
 		}
 	}
 
+	buildArgs := []string{"build"}
+	for _, arg := range testCase.BuildExtraArgs {
+		buildArgs = append(buildArgs, arg)
+	}
+	buildArgs = append(buildArgs, "--machine-readable", templatePath)
+
 	// Run build
-	buildCommand := exec.Command(packerbin, "build", "--machine-readable", templatePath)
+	buildCommand := exec.Command(packerbin, buildArgs...)
 	buildCommand.Env = append(buildCommand.Env, os.Environ()...)
 	buildCommand.Env = append(buildCommand.Env, "PACKER_LOG=1",
 		fmt.Sprintf("PACKER_LOG_PATH=%s", logfile))


### PR DESCRIPTION
When running an acceptance test, we may need to invoke Packer with extra flags to ensure it behaves as expected.

Therefore, we add this capability to the TestCase structure so it injects them verbatim in the command-line.