### PR TITLE
hcl2helper: preemptively panic on nil hcl spec

### DIFF
--- a/hcl2helper/values.go
+++ b/hcl2helper/values.go
@@ -77,6 +77,26 @@ func HCL2ValueFromConfig(conf interface{}, configSpec map[string]hcldec.Spec) ct
 	for k, v := range c {
 		spec := configSpec[k]
 
+		// During testing, I hit this problem and this felt bad to debug
+		// as I was working on other parts of the code at the same time.
+		//
+		// In the end, this may happen when the generated flat configs and
+		// the structures returned by the plugin are not synchronised, which
+		// causes the object spec to be out-of-sync with the data expected.
+		//
+		// Rather than letting the hcl library panic on a nil pointer problem,
+		// we do it here, with suggestions for users on how to potentially
+		// fix the problem, without needing to delve into the behaviour of
+		// the SDK and the HCL libraries.
+		if spec == nil {
+			panic(`The converted value failed to have its spec inferred from it, and will panic later down the process.
+This is likely due to an object spec being out of date in the plugin's code.
+You may retry this configuration with an up-to-date plugin, or if this is the latest version, please report this, as it is likely a bug to be fixed.
+If you are developing the plugin, please regenerate the HCL-related code with 'make generate', then rebuild the plugin with the up-to-date structures.
+
+If this doesn't fix your problem, this is likely a Packer bug, please consider opening an issue on the project so the team can look at it.`)
+		}
+
 		switch st := spec.(type) {
 		case *hcldec.BlockListSpec:
 			// This should be a slice of objects, so we need to take a special care


### PR DESCRIPTION
When the code from a plugin differs from its generated FlatConfig, we may encounter a nil object spec for the values in the output of a component.
This translates as a nil dereferencing panic within the hcl library, caused by a config and tags being out-of-sync.

To avoid users the hassle of delving in this code, and the hcl library's, we preemptively panic in the SDK code, with a message suggesting regenerating the code for the component's specs.