### PR TITLE
Bump supported version of go-cty to v1.13.3

### DIFF
--- a/cmd/packer-sdc/internal/fix/gocty.go
+++ b/cmd/packer-sdc/internal/fix/gocty.go
@@ -15,7 +15,7 @@ const (
 	sdkPath     string = "github.com/hashicorp/packer-plugin-sdk"
 	oldPath     string = "github.com/zclconf/go-cty"
 	newPath     string = "github.com/nywilken/go-cty"
-	newVersion  string = "1.12.1"
+	newVersion  string = "1.13.3"
 	modFilename string = "go.mod"
 )
 

--- a/cmd/packer-sdc/internal/fix/gocty_test.go
+++ b/cmd/packer-sdc/internal/fix/gocty_test.go
@@ -101,7 +101,6 @@ func TestFixGoCty_Unfixed(t *testing.T) {
 		},
 		{
 			name:       "out of date fix",
-			versionStr: "1.13.1",
 			fixtureDir: filepath.Join("testdata", "unfixed", "version"),
 		},
 	}

--- a/cmd/packer-sdc/internal/fix/testdata/fixed/basic/go.mod
+++ b/cmd/packer-sdc/internal/fix/testdata/fixed/basic/go.mod
@@ -8,4 +8,4 @@ require (
 	github.com/zclconf/go-cty v1.10.0
 )
 
-replace github.com/zclconf/go-cty => github.com/nywilken/go-cty v1.12.1
+replace github.com/zclconf/go-cty => github.com/nywilken/go-cty v1.13.3

--- a/cmd/packer-sdc/internal/fix/testdata/fixed/many-replace/go.mod
+++ b/cmd/packer-sdc/internal/fix/testdata/fixed/many-replace/go.mod
@@ -10,4 +10,4 @@ require (
 
 replace github.com/hashicorp/packer-plugin-sdk => github.com/example/packer-plugin-sdk v0.5.0
 
-replace github.com/zclconf/go-cty => github.com/nywilken/go-cty v1.12.1 // added by packer-sdc fix as noted in github.com/hashicorp/packer-plugin-sdk/issues/187
+replace github.com/zclconf/go-cty => github.com/nywilken/go-cty v1.13.3 // added by packer-sdc fix as noted in github.com/hashicorp/packer-plugin-sdk/issues/187

--- a/cmd/packer-sdc/internal/fix/testdata/unfixed/basic/fixed.go.mod
+++ b/cmd/packer-sdc/internal/fix/testdata/unfixed/basic/fixed.go.mod
@@ -8,4 +8,4 @@ require (
 	github.com/zclconf/go-cty v1.10.0
 )
 
-replace github.com/zclconf/go-cty => github.com/nywilken/go-cty v1.12.1 // added by packer-sdc fix as noted in github.com/hashicorp/packer-plugin-sdk/issues/187
+replace github.com/zclconf/go-cty => github.com/nywilken/go-cty v1.13.3 // added by packer-sdc fix as noted in github.com/hashicorp/packer-plugin-sdk/issues/187

--- a/cmd/packer-sdc/internal/fix/testdata/unfixed/many-replace/fixed.go.mod
+++ b/cmd/packer-sdc/internal/fix/testdata/unfixed/many-replace/fixed.go.mod
@@ -10,4 +10,4 @@ require (
 
 replace github.com/hashicorp/packer-plugin-sdk => github.com/example/packer-plugin-sdk v0.5.0
 
-replace github.com/zclconf/go-cty => github.com/nywilken/go-cty v1.12.1 // added by packer-sdc fix as noted in github.com/hashicorp/packer-plugin-sdk/issues/187
+replace github.com/zclconf/go-cty => github.com/nywilken/go-cty v1.13.3 // added by packer-sdc fix as noted in github.com/hashicorp/packer-plugin-sdk/issues/187

--- a/cmd/packer-sdc/internal/fix/testdata/unfixed/version/fixed.go.mod
+++ b/cmd/packer-sdc/internal/fix/testdata/unfixed/version/fixed.go.mod
@@ -8,4 +8,4 @@ require (
 	github.com/zclconf/go-cty v1.10.0
 )
 
-replace github.com/zclconf/go-cty => github.com/nywilken/go-cty v1.13.1 // added by packer-sdc fix as noted in github.com/hashicorp/packer-plugin-sdk/issues/187
+replace github.com/zclconf/go-cty => github.com/nywilken/go-cty v1.13.3 // added by packer-sdc fix as noted in github.com/hashicorp/packer-plugin-sdk/issues/187

--- a/cmd/packer-sdc/internal/fix/testdata/unfixed/version/go.mod
+++ b/cmd/packer-sdc/internal/fix/testdata/unfixed/version/go.mod
@@ -8,4 +8,4 @@ require (
 	github.com/zclconf/go-cty v1.10.0
 )
 
-replace github.com/zclconf/go-cty => github.com/nywilken/go-cty v1.13.1 // added by packer-sdc fix as noted in github.com/hashicorp/packer-plugin-sdk/issues/187
+replace github.com/zclconf/go-cty => github.com/nywilken/go-cty v1.12.1 // added by packer-sdc fix as noted in github.com/hashicorp/packer-plugin-sdk/issues/187

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/packer-plugin-sdk
 
-require github.com/zclconf/go-cty v1.12.1 // go-cty v1.11.0 removed gob encoding support so it cannot work with the Packer SDK as-is, you need to run `packer-sdc fix .' to change that
+require github.com/zclconf/go-cty v1.13.3 // go-cty v1.11.0 removed gob encoding support so it cannot work with the Packer SDK as-is, you need to run `packer-sdc fix .' to change that
 
 require (
 	cloud.google.com/go v0.105.0 // indirect
@@ -36,7 +36,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
-	github.com/hashicorp/hcl/v2 v2.16.2
+	github.com/hashicorp/hcl/v2 v2.19.1
 	github.com/hashicorp/vault/api v1.10.0
 	github.com/hashicorp/yamux v0.1.1
 	github.com/imdario/mergo v0.3.12 // indirect
@@ -82,6 +82,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.1 // indirect
 	github.com/antchfx/xmlquery v1.3.5 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/antchfx/xpath v1.1.11/go.mod h1:i54GszH55fYfBmoZXapTHN8T8tkcHfRgLyVww
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3 h1:ZSTrOEhiM5J5RFxEaFvMZVEAM1KvT1YzbEOwB2EAGjA=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
+github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
+github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-metrics v0.4.1 h1:hR91U9KYmb6bLBYLQjyM+3j+rcd/UhE+G78SFnF8gJA=
@@ -193,8 +195,8 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl/v2 v2.16.2 h1:mpkHZh/Tv+xet3sy3F9Ld4FyI2tUpWe9x3XtPx9f1a0=
-github.com/hashicorp/hcl/v2 v2.16.2/go.mod h1:JRmR89jycNkrrqnMmvPDMd56n1rQJ2Q6KocSLCMCXng=
+github.com/hashicorp/hcl/v2 v2.19.1 h1://i05Jqznmb2EXqa39Nsvyan2o5XyMowW5fnCKW5RPI=
+github.com/hashicorp/hcl/v2 v2.19.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.4/go.mod h1:mtBihi+LeNXGtG8L9dX59gAEa12BDtBQSp4v/YAJqrc=
 github.com/hashicorp/memberlist v0.5.0 h1:EtYPN8DpAURiapus508I4n9CzHs2W+8NZGbmmR/prTM=
@@ -348,8 +350,9 @@ github.com/ugorji/go/codec v1.2.6/go.mod h1:V6TCNZ4PHqoHGFZuSG1W8nrCzzdgA2DozYxW
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-github.com/zclconf/go-cty v1.12.1 h1:PcupnljUm9EIvbgSHQnHhUr3fO6oFmkOrvs2BAFNXXY=
-github.com/zclconf/go-cty v1.12.1/go.mod h1:s9IfD1LK5ccNMSWCVFCE2rJfHiZgi7JijgeWIMfhLvA=
+github.com/zclconf/go-cty v1.13.3 h1:m+b9q3YDbg6Bec5rr+KGy1MzEVzY/jC2X+YX4yqKtHI=
+github.com/zclconf/go-cty v1.13.3/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
+github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b h1:FosyBZYxY34Wul7O/MSKey3txpPYyCqVO5ZyceuQJEI=
 go.opencensus.io v0.23.0 h1:gqCw0LfLxScz8irSi8exQc7fyQ0fKQU/qnC/X8+V/1M=
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=


### PR DESCRIPTION
This change updates the supported versions for go-cty and hcl/v2. To assist plugin developers, including the Packer team, support the plugin ecosystem the packer-sdc fix command has been updated
to add, or updating applied fixes, for the go-cty fork to version 1.13.3. 

- Update go-cty fixer replace directive to github.com/nywilken/go-cty v1.13.3
- Bump github.com/zclconf/go-cty to v1.13.3
- Bump github.com/hashicorp/hcl/v2 to v1.19.1

Related to: #187 
Related to: #188 