### PR TITLE
packer-sdc/struct-markdown: Allow packer-internal as project directory for testing purposes

### DIFF
--- a/cmd/packer-sdc/internal/struct-markdown/struct_markdown.go
+++ b/cmd/packer-sdc/internal/struct-markdown/struct_markdown.go
@@ -47,7 +47,7 @@ func (cmd *Command) Run(args []string) int {
 
 	for dir := filepath.Dir(absFilePath); len(dir) > 0 && projectRoot == ""; dir = filepath.Dir(dir) {
 		base := filepath.Base(dir)
-		if base == "packer" {
+		if base == "packer" || base == "packer-internal" {
 			projectRoot = dir
 			filePath, _ = filepath.Rel(projectRoot, absFilePath)
 			docsFolder = filepath.Join("website", "content", "partials")


### PR DESCRIPTION
This change is being made to allow the invocation of struct-markdown to work against the internal Packer testing repo. The purpose of the repo is to allow for automated testing against unreleased versions of the Packer SDK.
