### PR TITLE
Fix documentation which referenced a non-existent property

### DIFF
--- a/communicator/config.go
+++ b/communicator/config.go
@@ -168,7 +168,7 @@ type SSH struct {
 	// **NOTE**: Guests using Windows with Win32-OpenSSH v9.1.0.0p1-Beta, scp
 	// (the default protocol for copying data) returns a a non-zero error code since the MOTW
 	// cannot be set, which cause any file transfer to fail. As a workaround you can override the transfer protocol
-	// with SFTP instead `ssh_file_transfer_protocol = "sftp"`.
+	// with SFTP instead `ssh_file_transfer_method = "sftp"`.
 	SSHFileTransferMethod string `mapstructure:"ssh_file_transfer_method"`
 	// A SOCKS proxy host to use for SSH connection
 	SSHProxyHost string `mapstructure:"ssh_proxy_host"`


### PR DESCRIPTION
Resolving a documentation problem that had me wasting an hour today. 

