### PR TITLE
Ui: add format-string alternatives to functions

### DIFF
--- a/packer/ui.go
+++ b/packer/ui.go
@@ -27,9 +27,12 @@ type TTY interface {
 // is formatted and various levels of output.
 type Ui interface {
 	Ask(string) (string, error)
+	Askf(string, ...any) (string, error)
 	Say(string)
+	Sayf(string, ...any)
 	Message(string)
 	Error(string)
+	Errorf(string, ...any)
 	Machine(string, ...string)
 	// TrackProgress(src string, currentSize, totalSize int64, stream io.ReadCloser) (body io.ReadCloser)
 	getter.ProgressTracker
@@ -51,6 +54,10 @@ type BasicUi struct {
 }
 
 var _ Ui = new(BasicUi)
+
+func (rw *BasicUi) Askf(query string, args ...any) (string, error) {
+	return rw.Ask(fmt.Sprintf(query, args...))
+}
 
 func (rw *BasicUi) Ask(query string) (string, error) {
 	rw.l.Lock()
@@ -99,6 +106,10 @@ func (rw *BasicUi) Ask(query string) (string, error) {
 	}
 }
 
+func (rw *BasicUi) Sayf(message string, args ...any) {
+	rw.Say(fmt.Sprintf(message, args...))
+}
+
 func (rw *BasicUi) Say(message string) {
 	rw.l.Lock()
 	defer rw.l.Unlock()
@@ -125,6 +136,10 @@ func (rw *BasicUi) Message(message string) {
 	if err != nil {
 		log.Printf("[ERR] Failed to write to UI: %s", err)
 	}
+}
+
+func (rw *BasicUi) Errorf(message string, args ...any) {
+	rw.Error(fmt.Sprintf(message, args...))
 }
 
 func (rw *BasicUi) Error(message string) {
@@ -164,6 +179,13 @@ type SafeUi struct {
 
 var _ Ui = new(SafeUi)
 
+func (u *SafeUi) Askf(s string, args ...any) (string, error) {
+	u.Sem <- 1
+	ret, err := u.Ui.Askf(s, args...)
+	<-u.Sem
+
+	return ret, err
+}
 func (u *SafeUi) Ask(s string) (string, error) {
 	u.Sem <- 1
 	ret, err := u.Ui.Ask(s)
@@ -172,6 +194,11 @@ func (u *SafeUi) Ask(s string) (string, error) {
 	return ret, err
 }
 
+func (u *SafeUi) Sayf(s string, args ...any) {
+	u.Sem <- 1
+	u.Ui.Sayf(s, args...)
+	<-u.Sem
+}
 func (u *SafeUi) Say(s string) {
 	u.Sem <- 1
 	u.Ui.Say(s)
@@ -184,6 +211,11 @@ func (u *SafeUi) Message(s string) {
 	<-u.Sem
 }
 
+func (u *SafeUi) Errorf(s string, args ...any) {
+	u.Sem <- 1
+	u.Ui.Errorf(s, args...)
+	<-u.Sem
+}
 func (u *SafeUi) Error(s string) {
 	u.Sem <- 1
 	u.Ui.Error(s)

--- a/packer/ui_mock.go
+++ b/packer/ui_mock.go
@@ -5,6 +5,7 @@ package packer
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -45,12 +46,18 @@ type MockUi struct {
 	ProgressBarCloseCalled bool
 }
 
+func (u *MockUi) Askf(query string, args ...any) (string, error) {
+	return u.Ask(fmt.Sprintf(query, args...))
+}
 func (u *MockUi) Ask(query string) (string, error) {
 	u.AskCalled = true
 	u.AskQuery = query
 	return "foo", nil
 }
 
+func (u *MockUi) Errorf(message string, args ...any) {
+	u.Error(fmt.Sprintf(message, args...))
+}
 func (u *MockUi) Error(message string) {
 	u.ErrorCalled = true
 	u.ErrorMessage = message
@@ -67,6 +74,9 @@ func (u *MockUi) Message(message string) {
 	u.MessageMessage = message
 }
 
+func (u *MockUi) Sayf(message string, args ...any) {
+	u.Say(fmt.Sprintf(message, args...))
+}
 func (u *MockUi) Say(message string) {
 	u.SayCalled = true
 	sayMessage := SayMessage{

--- a/rpc/ui.go
+++ b/rpc/ui.go
@@ -4,6 +4,7 @@
 package rpc
 
 import (
+	"fmt"
 	"log"
 
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
@@ -31,11 +32,17 @@ type UiMachineArgs struct {
 	Args     []string
 }
 
+func (u *Ui) Askf(query string, args ...any) (string, error) {
+	return u.Ask(fmt.Sprintf(query, args...))
+}
 func (u *Ui) Ask(query string) (result string, err error) {
 	err = u.client.Call("Ui.Ask", query, &result)
 	return
 }
 
+func (u *Ui) Errorf(message string, args ...any) {
+	u.Error(fmt.Sprintf(message, args...))
+}
 func (u *Ui) Error(message string) {
 	if err := u.client.Call("Ui.Error", message, new(interface{})); err != nil {
 		log.Printf("Error in Ui.Error RPC call: %s", err)
@@ -59,6 +66,9 @@ func (u *Ui) Message(message string) {
 	}
 }
 
+func (u *Ui) Sayf(message string, args ...any) {
+	u.Say(fmt.Sprintf(message, args...))
+}
 func (u *Ui) Say(message string) {
 	if err := u.client.Call("Ui.Say", message, new(interface{})); err != nil {
 		log.Printf("Error in Ui.Say RPC call: %s", err)

--- a/rpc/ui_test.go
+++ b/rpc/ui_test.go
@@ -5,6 +5,7 @@ package rpc
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"reflect"
 	"testing"
@@ -28,12 +29,18 @@ type testUi struct {
 	progressBarCloseCalled bool
 }
 
+func (u *testUi) Askf(query string, args ...any) (string, error) {
+	return u.Ask(fmt.Sprintf(query, args...))
+}
 func (u *testUi) Ask(query string) (string, error) {
 	u.askCalled = true
 	u.askQuery = query
 	return "foo", nil
 }
 
+func (u *testUi) Errorf(message string, args ...any) {
+	u.Error(fmt.Sprintf(message, args...))
+}
 func (u *testUi) Error(message string) {
 	u.errorCalled = true
 	u.errorMessage = message
@@ -50,6 +57,9 @@ func (u *testUi) Message(message string) {
 	u.messageMessage = message
 }
 
+func (u *testUi) Sayf(message string, args ...any) {
+	u.Say(fmt.Sprintf(message, args...))
+}
 func (u *testUi) Say(message string) {
 	u.sayCalled = true
 	u.sayMessage = message


### PR DESCRIPTION
The say/error/ask methods on Ui only accept formatted strings, which is a bit cumbersome to do at callsite every time we need to print out something formatted with dynamic information.

To reduce that cumbersomness, we add some convenience alternatives to the Ui implementations in the SDK, so they now expose Sayf, Askf and Errorf in addition to the rest.