### PR TITLE
Version parsing rehaul

### DIFF
--- a/plugin/set_test.go
+++ b/plugin/set_test.go
@@ -45,12 +45,12 @@ func TestSet(t *testing.T) {
 	set.RegisterProvisioner("example-2", new(MockProvisioner))
 	set.RegisterDatasource("example", new(MockDatasource))
 	set.RegisterDatasource("example-2", new(MockDatasource))
-	set.SetVersion(pluginVersion.InitializePluginVersion(
-		"1.1.1", ""))
+	set.SetVersion(pluginVersion.NewPluginVersion(
+		"1.1.1", "", ""))
 
 	outputDesc := set.description()
 
-	sdkVersion := pluginVersion.InitializePluginVersion(pluginVersion.Version, pluginVersion.VersionPrerelease)
+	sdkVersion := pluginVersion.NewPluginVersion(pluginVersion.Version, pluginVersion.VersionPrerelease, "")
 	if diff := cmp.Diff(SetDescription{
 		Version:        "1.1.1",
 		SDKVersion:     sdkVersion.String(),

--- a/version/version.go
+++ b/version/version.go
@@ -47,6 +47,11 @@ func InitializePluginVersion(vers, versionPrerelease string) *PluginVersion {
 // As NewRawVersion, if the version is invalid, it will panic.
 func NewRawVersion(rawSemVer string) *PluginVersion {
 	vers := version.Must(version.NewVersion(rawSemVer))
+
+	if len(vers.Segments()) != 3 {
+		panic(fmt.Sprintf("versions should only have 3 segments, %q had %d", rawSemVer, len(vers.Segments())))
+	}
+
 	return &PluginVersion{
 		version:           vers.Core().String(),
 		versionPrerelease: vers.Prerelease(),
@@ -81,16 +86,7 @@ func NewPluginVersion(vers, versionPrerelease, versionMetadata string) *PluginVe
 		versionRawString = fmt.Sprintf("%s+%s", versionRawString, versionMetadata)
 	}
 
-	// This call initializes the SemVer to make sure that if Packer crashes due
-	// to an invalid SemVer it's at the very beginning of the Packer run.
-	semVer := version.Must(version.NewVersion(versionRawString))
-
-	return &PluginVersion{
-		version:           semVer.Core().String(),
-		versionPrerelease: semVer.Prerelease(),
-		versionMetadata:   semVer.Metadata(),
-		semVer:            semVer,
-	}
+	return NewRawVersion(versionRawString)
 }
 
 type PluginVersion struct {

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,6 @@
 package version
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/hashicorp/go-version"
@@ -81,6 +80,7 @@ func NewPluginVersion(vers, versionPrerelease, versionMetadata string) *PluginVe
 	if versionMetadata != "" {
 		versionRawString = fmt.Sprintf("%s+%s", versionRawString, versionMetadata)
 	}
+
 	// This call initializes the SemVer to make sure that if Packer crashes due
 	// to an invalid SemVer it's at the very beginning of the Packer run.
 	semVer := version.Must(version.NewVersion(versionRawString))
@@ -112,18 +112,18 @@ type PluginVersion struct {
 func (p *PluginVersion) SetMetadata(meta string) {
 	p.versionMetadata = meta
 }
-func (p *PluginVersion) FormattedVersion() string {
-	var versionString bytes.Buffer
-	fmt.Fprintf(&versionString, "%s", p.version)
-	if p.versionPrerelease != "" {
-		fmt.Fprintf(&versionString, "-%s", p.versionPrerelease)
 
-		if GitCommit != "" {
-			fmt.Fprintf(&versionString, " (%s)", GitCommit)
-		}
+func (p *PluginVersion) FormattedVersion() string {
+	versionString := p.semVer.String()
+
+	// Given there could be some metadata already, we add the commit to the
+	// reported version as part of the metadata, with a `-` spearator if
+	// the metadata is already there, otherwise we make it the metadata
+	if GitCommit != "" {
+		versionString = fmt.Sprintf("%s (%s)", versionString, GitCommit)
 	}
 
-	return versionString.String()
+	return versionString
 }
 
 func (p *PluginVersion) SemVer() *version.Version {

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -62,6 +62,14 @@ func Test_PluginVersionCreate(t *testing.T) {
 			true,
 			"",
 		},
+		{
+			"4-parts version, should not be accepted",
+			"1.1.1.1",
+			"",
+			"",
+			true,
+			"",
+		},
 	}
 
 	for _, tt := range tests {

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -101,6 +101,13 @@ func TestFormattedVersionString(t *testing.T) {
 	ver := InitializePluginVersion("1.0.0", "dev")
 	formatted := ver.FormattedVersion()
 	if formatted != expectedVersion {
-		t.Fatalf("Expected formatted version %q; got %q", expectedVersion, formatted)
+		t.Errorf("Expected formatted version %q; got %q", expectedVersion, formatted)
+	}
+
+	expectedVersion = fmt.Sprintf("1.0.0-dev+meta (%s)", GitCommit)
+	ver = NewPluginVersion("1.0.0", "dev", "meta")
+	formatted = ver.FormattedVersion()
+	if formatted != expectedVersion {
+		t.Errorf("Expected formatted version %q; got %q", expectedVersion, formatted)
 	}
 }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,0 +1,106 @@
+package version
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_PluginVersionCreate(t *testing.T) {
+	tests := []struct {
+		name                string
+		coreVersion         string
+		preVersion          string
+		metaVersion         string
+		expectError         bool
+		expectVersionString string
+	}{
+		{
+			"Valid semver core only version",
+			"1.0.0",
+			"",
+			"",
+			false,
+			"1.0.0",
+		},
+		{
+			"Valid semver, should get canonical version",
+			"01.001.001",
+			"",
+			"",
+			false,
+			"1.1.1",
+		},
+		{
+			"Valid semver with prerelease, should get canonical version",
+			"1.001.010",
+			"dev",
+			"",
+			false,
+			"1.1.10-dev",
+		},
+		{
+			"Valid semver with metadata, should get canonical version",
+			"1.001.010",
+			"",
+			"123abcdef",
+			false,
+			"1.1.10+123abcdef",
+		},
+		{
+			"Valid semver with prerelease and metadata, should get canonical version",
+			"1.001.010",
+			"dev",
+			"123abcdef",
+			false,
+			"1.1.10-dev+123abcdef",
+		},
+		{
+			"Invalid version, should fail",
+			".1.1",
+			"",
+			"",
+			true,
+			"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				panicMsg := recover()
+				if !tt.expectError && panicMsg != nil {
+					t.Errorf("creating version panicked, should not have.")
+				}
+
+				if tt.expectError && panicMsg == nil {
+					t.Errorf("creating version should have panicked, but did not.")
+				}
+
+				if panicMsg != nil {
+					t.Logf("panic message was: %v", panicMsg)
+				}
+			}()
+
+			ver := NewPluginVersion(tt.coreVersion, tt.preVersion, tt.metaVersion)
+			verStr := ver.String()
+			if verStr != tt.expectVersionString {
+				t.Errorf("string format mismatch, version created is %q, expected %q", verStr, tt.expectVersionString)
+			}
+		})
+	}
+}
+
+func TestFormattedVersionString(t *testing.T) {
+	GitCommit = "abcdef12345"
+	defer func() {
+		GitCommit = ""
+	}()
+
+	expectedVersion := fmt.Sprintf("1.0.0-dev (%s)", GitCommit)
+
+	ver := InitializePluginVersion("1.0.0", "dev")
+	formatted := ver.FormattedVersion()
+	if formatted != expectedVersion {
+		t.Fatalf("Expected formatted version %q; got %q", expectedVersion, formatted)
+	}
+}


### PR DESCRIPTION
As it stands now, plugin developers can only specify a version's core semver-compatible version, and a prerelease.
In usage though, some plugins use metadata to add some extra context on the binary that was built, like the git commit, or the delta between the last release and the current HEAD from which a plugin was built. 

This, coupled with the 1.11.0 changes to plugin loading and version support, means that we cannot support such a workflow with the current code, as we will now start enforcing proper semver for plugins, so we are at risk of having plugins either not load, or lose information when releasing.

Therefore as an attempt to address those issues, we are adding official support in the SDK for metadata in versions. That change introduces two new functions: `NewPluginVersion` and `NewRawVersion`. Both are intended as replacements for the now deprecated `InitializePluginVersion`.

In addition to this change, we are also limiting the number of segments to 3 in the version number, there are too many unknowns around 4-segmented version numbers, in addition to this not being semver compliant (despite the library supporting them).

cc @NorseGaud @torarnv @chris-rock since we've had recent exchanges regarding plugins recently on your respective repositories, this PR should cement the addition of metadata to what is supported for versions. Please feel free to take a look at this code, and let me know your thoughts, I'd like to know if this kind of interface would suit your development practices.
Thanks in advance!
