### PR TITLE
version: don't remake semVer if not nil

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -123,12 +123,6 @@ func (p *PluginVersion) FormattedVersion() string {
 }
 
 func (p *PluginVersion) SemVer() *version.Version {
-	if p.semVer != nil {
-		// SemVer is an instance of version.Version. This has the secondary
-		// benefit of verifying during tests and init time that our version is a
-		// proper semantic version, which should always be the case.
-		p.semVer = version.Must(version.NewVersion(p.version))
-	}
 	return p.semVer
 }
 


### PR DESCRIPTION
The SemVer function of a PluginVersion returns the version.Version instance bound to the PluginVersion.

In former implementations of the structure, this could be nil in some cases, as only the version components were being registered, and the code would make sure that they were a valid semver version.

Recent changes reorganised this code by making the semVer attribute always present, so while theoretically it could be nil, this would indicate a manipulation error.

Therefore, we don't need to perform this check to re-create the semVer attribute, and by that change we fix the underlying issue that made semVer drop its pre-release/metadata parts when doing so.
