### PR TITLE
communicator: fix reference to ssh_method in docs

### DIFF
--- a/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/SSH-not-required.mdx
+++ b/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/SSH-not-required.mdx
@@ -78,7 +78,7 @@
   **NOTE**: Guests using Windows with Win32-OpenSSH v9.1.0.0p1-Beta, scp
   (the default protocol for copying data) returns a a non-zero error code since the MOTW
   cannot be set, which cause any file transfer to fail. As a workaround you can override the transfer protocol
-  with SFTP instead `ssh_file_transfer_protocol = "sftp"`.
+  with SFTP instead `ssh_file_transfer_method = "sftp"`.
 
 - `ssh_proxy_host` (string) - A SOCKS proxy host to use for SSH connection
 

--- a/communicator/config.go
+++ b/communicator/config.go
@@ -168,7 +168,7 @@ type SSH struct {
 	// **NOTE**: Guests using Windows with Win32-OpenSSH v9.1.0.0p1-Beta, scp
 	// (the default protocol for copying data) returns a a non-zero error code since the MOTW
 	// cannot be set, which cause any file transfer to fail. As a workaround you can override the transfer protocol
-	// with SFTP instead `ssh_file_transfer_protocol = "sftp"`.
+	// with SFTP instead `ssh_file_transfer_method = "sftp"`.
 	SSHFileTransferMethod string `mapstructure:"ssh_file_transfer_method"`
 	// A SOCKS proxy host to use for SSH connection
 	SSHProxyHost string `mapstructure:"ssh_proxy_host"`


### PR DESCRIPTION
As pointed out in [a Packer PR](https://github.com/hashicorp/packer/pull/12949), the option's name does not match its real name for the ssh file transfer method.

This commit fixes that mismatch.