### PR TITLE
fix: confighelper.Trilean to show as boolean

### DIFF
--- a/cmd/packer-sdc/internal/struct-markdown/struct_markdown.go
+++ b/cmd/packer-sdc/internal/struct-markdown/struct_markdown.go
@@ -166,7 +166,7 @@ func (cmd *Command) Run(args []string) int {
 			switch fieldType {
 			case "time.Duration":
 				fieldType = `duration string | ex: "1h5m2s"`
-			case "config.Trilean":
+			case "config.Trilean", "confighelper.Trilean":
 				fieldType = `boolean`
 			case "config.NameValues":
 				fieldType = `[]{name string, value string}`


### PR DESCRIPTION
Users do not need to know what's `confighelper.Trilean` similar to https://github.com/hashicorp/packer/pull/8673 to avoid confusion.