### PR TITLE
Fix ipv6 addresses format

### DIFF
--- a/communicator/step_connect_ssh.go
+++ b/communicator/step_connect_ssh.go
@@ -7,13 +7,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"golang.org/x/term"
 	"io"
 	"log"
 	"net"
 	"os"
 	"strings"
 	"time"
+
+	"golang.org/x/term"
 
 	helperssh "github.com/hashicorp/packer-plugin-sdk/communicator/ssh"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
@@ -101,8 +102,7 @@ func (s *StepConnectSSH) waitForSSH(state multistep.StateBag, ctx context.Contex
 	if s.Config.SSHBastionHost != "" {
 		// The protocol is hardcoded for now, but may be configurable one day
 		bProto = "tcp"
-		bAddr = fmt.Sprintf(
-			"%s:%d", s.Config.SSHBastionHost, s.Config.SSHBastionPort)
+		bAddr = net.JoinHostPort(s.Config.SSHBastionHost, fmt.Sprint(s.Config.SSHBastionPort))
 
 		conf, err := sshBastionConfig(s.Config)
 		if err != nil {
@@ -112,7 +112,7 @@ func (s *StepConnectSSH) waitForSSH(state multistep.StateBag, ctx context.Contex
 	}
 
 	if s.Config.SSHProxyHost != "" {
-		pAddr = fmt.Sprintf("%s:%d", s.Config.SSHProxyHost, s.Config.SSHProxyPort)
+		pAddr = net.JoinHostPort(s.Config.SSHProxyHost, fmt.Sprint(s.Config.SSHProxyPort))
 		if s.Config.SSHProxyUsername != "" {
 			pAuth = new(proxy.Auth)
 			pAuth.User = s.Config.SSHProxyUsername
@@ -165,7 +165,7 @@ func (s *StepConnectSSH) waitForSSH(state multistep.StateBag, ctx context.Contex
 
 		// Attempt to connect to SSH port
 		var connFunc func() (net.Conn, error)
-		address := fmt.Sprintf("%s:%d", host, port)
+		address := net.JoinHostPort(host, fmt.Sprint(port))
 		if bAddr != "" {
 			log.Printf("[INFO] connecting with SSH to host %s through bastion at %s",
 				address, bAddr)

--- a/communicator/step_connect_winrm.go
+++ b/communicator/step_connect_winrm.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -213,7 +214,7 @@ func (s *StepConnectWinRM) waitForWinRM(state multistep.StateBag, ctx context.Co
 // setNoProxy configures the $NO_PROXY env var
 func setNoProxy(host string, port int) error {
 	current := os.Getenv("NO_PROXY")
-	p := fmt.Sprintf("%s:%d", host, port)
+	p := net.JoinHostPort(host, fmt.Sprint(port))
 	if current == "" {
 		return os.Setenv("NO_PROXY", p)
 	}

--- a/multistep/commonsteps/step_provision_test.go
+++ b/multistep/commonsteps/step_provision_test.go
@@ -5,6 +5,7 @@ package commonsteps
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"testing"
 
@@ -43,7 +44,7 @@ func TestPopulateProvisionHookData(t *testing.T) {
 	packerRunUUID := "1fa225b8-27d1-42d1-9117-221772213962"
 	httpIP := "10.0.2.2"
 	httpPort := 2222
-	httpAddr := fmt.Sprintf("%s:%d", httpIP, httpPort)
+	httpAddr := net.JoinHostPort(httpIP, fmt.Sprint(httpPort))
 
 	state.Put("generated_data", generatedData)
 	state.Put("instance_id", instanceId)

--- a/net/configure_port.go
+++ b/net/configure_port.go
@@ -99,7 +99,7 @@ func (lc ListenRangeConfig) Listen(ctx context.Context) (*Listener, error) {
 			return ErrPortFileLocked(port)
 		}
 
-		l, err := lc.ListenConfig.Listen(ctx, lc.Network, fmt.Sprintf("%s:%d", lc.Addr, port))
+		l, err := lc.ListenConfig.Listen(ctx, lc.Network, net.JoinHostPort(lc.Addr, fmt.Sprint(port)))
 		if err != nil {
 			if err := lock.Unlock(); err != nil {
 				log.Fatalf("Could not unlock file lock for port %d: %v", port, err)

--- a/sdk-internals/communicator/winrm/communicator.go
+++ b/sdk-internals/communicator/winrm/communicator.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -193,7 +194,7 @@ func (c *Communicator) getClientConfig() *winrmcp.Config {
 }
 
 func (c *Communicator) newCopyClient() (*winrmcp.Winrmcp, error) {
-	addr := fmt.Sprintf("%s:%d", c.endpoint.Host, c.endpoint.Port)
+	addr := net.JoinHostPort(c.endpoint.Host, fmt.Sprint(c.endpoint.Port))
 	clientConfig := c.getClientConfig()
 	return winrmcp.New(addr, clientConfig)
 }


### PR DESCRIPTION
When joining an ipv6 host and a port, the host must be wrapped between brackets, otherwise the port will become part of the host.

Closes #245 