### PR TITLE
plugin/set.go: Add test for validation protobuf flag parsing

### DIFF
--- a/plugin/set.go
+++ b/plugin/set.go
@@ -133,15 +133,6 @@ func (i *Set) parseProtobufFlag(args ...string) []string {
 	}
 
 	i.useProto = true
-
-	if protobufPos == 0 {
-		return args[1:]
-	}
-
-	if protobufPos == len(args)-1 {
-		return args[:len(args)-1]
-	}
-
 	return append(args[:protobufPos], args[protobufPos+1:]...)
 }
 

--- a/plugin/set.go
+++ b/plugin/set.go
@@ -120,20 +120,15 @@ func (i *Set) Run() error {
 //
 // It then returns the args without it for the commands to process them.
 func (i *Set) parseProtobufFlag(args ...string) []string {
-	protobufPos := -1
-	for i, arg := range args {
+	parsedArgs := make([]string, 0, len(args))
+	for _, arg := range args {
 		if arg == "--protobuf" {
-			protobufPos = i
-			break
+			i.useProto = true
+			continue
 		}
+		parsedArgs = append(parsedArgs, arg)
 	}
-
-	if protobufPos == -1 {
-		return args
-	}
-
-	i.useProto = true
-	return append(args[:protobufPos], args[protobufPos+1:]...)
+	return parsedArgs
 }
 
 func (i *Set) RunCommand(args ...string) error {

--- a/plugin/set_test.go
+++ b/plugin/set_test.go
@@ -69,3 +69,58 @@ func TestSet(t *testing.T) {
 		t.Fatalf("Unexpected error: %s", diff)
 	}
 }
+
+func TestSetProtobufArgParsing(t *testing.T) {
+	testCases := []struct {
+		name     string
+		useProto bool
+		in, out  []string
+	}{
+		{
+			name:     "no --protobuf argument provided",
+			in:       []string{"example", "example-2"},
+			out:      []string{"example", "example-2"},
+			useProto: false,
+		},
+		{
+			name:     "providing --protobuf as first argument",
+			in:       []string{"--protobuf", "example", "example-2"},
+			out:      []string{"example", "example-2"},
+			useProto: true,
+		},
+		{
+			name:     "providing --protobuf as last argument",
+			in:       []string{"example", "example-2", "--protobuf"},
+			out:      []string{"example", "example-2"},
+			useProto: true,
+		},
+		{
+			name:     "providing --protobuf as middle argument",
+			in:       []string{"example", "--protobuf", "example-2"},
+			out:      []string{"example", "example-2"},
+			useProto: true,
+		},
+		//{
+		//name:     "providing --protobuf multiple times",
+		//in:       []string{"--protobuf", "--protobuf", "example-2"},
+		//out:      []string{"example-2"},
+		//useProto: true,
+		//},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			set := NewSet()
+			got := set.parseProtobufFlag(tc.in...)
+
+			if diff := cmp.Diff(got, tc.out); diff != "" {
+				t.Errorf("Unexpected args: %s", diff)
+			}
+
+			if set.useProto != tc.useProto {
+				t.Errorf("expected useProto to be %t when %s but got %t", tc.useProto, tc.name, set.useProto)
+			}
+		})
+
+	}
+}

--- a/plugin/set_test.go
+++ b/plugin/set_test.go
@@ -78,34 +78,34 @@ func TestSetProtobufArgParsing(t *testing.T) {
 	}{
 		{
 			name:     "no --protobuf argument provided",
-			in:       []string{"example", "example-2"},
-			out:      []string{"example", "example-2"},
+			in:       []string{"start", "builder", "example"},
+			out:      []string{"start", "builder", "example"},
 			useProto: false,
 		},
 		{
 			name:     "providing --protobuf as first argument",
-			in:       []string{"--protobuf", "example", "example-2"},
-			out:      []string{"example", "example-2"},
+			in:       []string{"--protobuf", "start", "builder", "example"},
+			out:      []string{"start", "builder", "example"},
 			useProto: true,
 		},
 		{
 			name:     "providing --protobuf as last argument",
-			in:       []string{"example", "example-2", "--protobuf"},
-			out:      []string{"example", "example-2"},
+			in:       []string{"start", "builder", "example", "--protobuf"},
+			out:      []string{"start", "builder", "example"},
 			useProto: true,
 		},
 		{
 			name:     "providing --protobuf as middle argument",
-			in:       []string{"example", "--protobuf", "example-2"},
-			out:      []string{"example", "example-2"},
+			in:       []string{"start", "builder", "--protobuf", "example"},
+			out:      []string{"start", "builder", "example"},
 			useProto: true,
 		},
-		//{
-		//name:     "providing --protobuf multiple times",
-		//in:       []string{"--protobuf", "--protobuf", "example-2"},
-		//out:      []string{"example-2"},
-		//useProto: true,
-		//},
+		{
+			name:     "providing --protobuf multiple times",
+			in:       []string{"--protobuf", "start", "builder", "--protobuf", "example", "--protobuf"},
+			out:      []string{"start", "builder", "example"},
+			useProto: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This change refactors the logic inside of parseProtobufFlag to handle the case where multiple `--protobuf` flags are specified, while removing unnecessary guard clauses. 

In addition to the refactor tests were added to validate the behavior before and after the reactor

```
~>  go test ./plugin/... -v
=== RUN   TestPluginServerRandom
--- PASS: TestPluginServerRandom (0.00s)
=== RUN   TestSet
--- PASS: TestSet (0.00s)
=== RUN   TestSetProtobufArgParsing
=== RUN   TestSetProtobufArgParsing/no_--protobuf_argument_provided
=== RUN   TestSetProtobufArgParsing/providing_--protobuf_as_first_argument
=== RUN   TestSetProtobufArgParsing/providing_--protobuf_as_last_argument
=== RUN   TestSetProtobufArgParsing/providing_--protobuf_as_middle_argument
=== RUN   TestSetProtobufArgParsing/providing_--protobuf_multiple_times
--- PASS: TestSetProtobufArgParsing (0.00s)
    --- PASS: TestSetProtobufArgParsing/no_--protobuf_argument_provided (0.00s)
    --- PASS: TestSetProtobufArgParsing/providing_--protobuf_as_first_argument (0.00s)
    --- PASS: TestSetProtobufArgParsing/providing_--protobuf_as_last_argument (0.00s)
    --- PASS: TestSetProtobufArgParsing/providing_--protobuf_as_middle_argument (0.00s)
    --- PASS: TestSetProtobufArgParsing/providing_--protobuf_multiple_times (0.00s)
PASS
ok      github.com/hashicorp/packer-plugin-sdk/plugin   0.250s

```
