### PR TITLE
Add support for aix/ppc64 build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
-	github.com/bgentry/speakeasy v0.1.0 // indirect
+	github.com/bgentry/speakeasy v0.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/go-jose/go-jose/v4 v4.0.1 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
@@ -96,7 +96,7 @@ require (
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
-	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
+	github.com/hashicorp/go-sockaddr v1.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/serf v0.10.1 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,9 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
-github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/bgentry/speakeasy v0.2.0 h1:tgObeVOf8WAvtuAX6DhJ4xks4CFNwPDZiqzGqIHE51E=
+github.com/bgentry/speakeasy v0.2.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=
 github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -187,8 +188,9 @@ github.com/hashicorp/go-secure-stdlib/strutil v0.1.1/go.mod h1:gKOamz3EwoIoJq7ml
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 h1:kes8mmyCpxJsI7FTwtzRqEy9CdjCtrXrXGuOpxEA7Ts=
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.2/go.mod h1:Gou2R9+il93BqX25LAKCLuM+y9U2T4hlwvT1yprcna4=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
-github.com/hashicorp/go-sockaddr v1.0.2 h1:ztczhD1jLxIRjVejw8gFomI1BQZOe2WoVOu0SyteCQc=
 github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=
+github.com/hashicorp/go-sockaddr v1.0.7 h1:G+pTkSO01HpR5qCxg7lxfsFEZaG+C0VssTy/9dbT+Fw=
+github.com/hashicorp/go-sockaddr v1.0.7/go.mod h1:FZQbEYa1pxkQ7WLpyXJ6cbjpT8q0YgQaK/JakXqGyWw=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/packer/cache_config_unix.go
+++ b/packer/cache_config_unix.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:build darwin || freebsd || linux || netbsd || openbsd || solaris
+//go:build aix || darwin || freebsd || linux || netbsd || openbsd || solaris
 
 package packer
 

--- a/packer/cache_config_unix_test.go
+++ b/packer/cache_config_unix_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:build darwin || freebsd || linux || netbsd || openbsd || solaris
+//go:build aix || darwin || freebsd || linux || netbsd || openbsd || solaris
 
 package packer
 

--- a/pathing/config_file_unix.go
+++ b/pathing/config_file_unix.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:build darwin || freebsd || linux || netbsd || openbsd || solaris
+//go:build aix || darwin || freebsd || linux || netbsd || openbsd || solaris
 
 package pathing
 

--- a/pathing/config_file_unix_test.go
+++ b/pathing/config_file_unix_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:build darwin || freebsd || linux || netbsd || openbsd || solaris
+//go:build aix || darwin || freebsd || linux || netbsd || openbsd || solaris
 
 package pathing
 


### PR DESCRIPTION
This PR adds support for building for the aix/ppc64 target. The following minor changes have been made:

- Add build tags where necessary to include `aix` with the other Unixes.
- Update dependencies to versions that support building for aix/ppc64

To reproduce the build failure:
```
$ GOOS=aix GOARCH=ppc64 go build ./...
# github.com/hashicorp/packer-plugin-sdk/pathing
pathing/config_file.go:41:9: undefined: configDir
pathing/config_file.go:88:28: undefined: defaultConfigFile
# github.com/bgentry/speakeasy
../../../go/pkg/mod/github.com/bgentry/speakeasy@v0.1.0/speakeasy.go:23:18: undefined: getPassword
# github.com/hashicorp/go-sockaddr
../../../go/pkg/mod/github.com/hashicorp/go-sockaddr@v1.0.2/route_info.go:14:10: undefined: routeInfo
../../../go/pkg/mod/github.com/hashicorp/go-sockaddr@v1.0.2/ifaddrs.go:116:13: undefined: NewRouteInfo
../../../go/pkg/mod/github.com/hashicorp/go-sockaddr@v1.0.2/ifaddrs.go:276:13: undefined: NewRouteInfo
```

The above command returns success when run with this PR's changes and the go-cty fix.

Test results from an AIX 7.3 system, again with the go-cty fix applied:
```
-bash-5.2$ go version
go version go1.23.1 aix/ppc64
-bash-5.2$ go test ./...
?       github.com/hashicorp/packer-plugin-sdk/acctest  [no test files]
?       github.com/hashicorp/packer-plugin-sdk/acctest/provisioneracc   [no test files]
?       github.com/hashicorp/packer-plugin-sdk/acctest/testutils        [no test files]
ok      github.com/hashicorp/packer-plugin-sdk/adapter  0.138s
?       github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc   [no test files]
?       github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc/internal/cmd      [no test files]
?       github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc/internal/plugincheck      [no test files]
?       github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc/internal/test-data/field-conflict [no test files]
?       github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc/internal/test-data/packer-plugin-happycloud/builder/happycloud    [no test files]
?       github.com/hashicorp/packer-plugin-sdk/common   [no test files]
?       github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc/internal/test-data/tag-conflict   [no test files]
?       github.com/hashicorp/packer-plugin-sdk/didyoumean       [no test files]
?       github.com/hashicorp/packer-plugin-sdk/filelock [no test files]
?       github.com/hashicorp/packer-plugin-sdk/json     [no test files]
ok      github.com/hashicorp/packer-plugin-sdk/bootcommand      4.746s
ok      github.com/hashicorp/packer-plugin-sdk/chroot   0.353s
ok      github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc/internal/fix      0.406s
ok      github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc/internal/fs       0.331s
ok      github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc/internal/mapstructure-to-hcl2     0.536s
ok      github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc/internal/renderdocs       0.234s
ok      github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc/internal/struct-markdown  0.238s
?       github.com/hashicorp/packer-plugin-sdk/random   [no test files]
?       github.com/hashicorp/packer-plugin-sdk/tmp      [no test files]
ok      github.com/hashicorp/packer-plugin-sdk/communicator     11.654s
ok      github.com/hashicorp/packer-plugin-sdk/communicator/ssh 6.864s
ok      github.com/hashicorp/packer-plugin-sdk/communicator/sshkey      3.503s
ok      github.com/hashicorp/packer-plugin-sdk/guestexec        0.237s
ok      github.com/hashicorp/packer-plugin-sdk/hcl2helper       0.143s
ok      github.com/hashicorp/packer-plugin-sdk/multistep        0.349s
ok      github.com/hashicorp/packer-plugin-sdk/multistep/commonsteps    0.626s
ok      github.com/hashicorp/packer-plugin-sdk/net      1.172s
ok      github.com/hashicorp/packer-plugin-sdk/packer   0.195s
ok      github.com/hashicorp/packer-plugin-sdk/packer/registry/image    0.214s
ok      github.com/hashicorp/packer-plugin-sdk/packerbuilderdata        0.182s
ok      github.com/hashicorp/packer-plugin-sdk/pathing  0.099s
ok      github.com/hashicorp/packer-plugin-sdk/plugin   0.072s
ok      github.com/hashicorp/packer-plugin-sdk/retry    0.060s
ok      github.com/hashicorp/packer-plugin-sdk/rpc      0.123s
ok      github.com/hashicorp/packer-plugin-sdk/sdk-internals/communicator/none  0.055s
ok      github.com/hashicorp/packer-plugin-sdk/sdk-internals/communicator/ssh   0.116s
ok      github.com/hashicorp/packer-plugin-sdk/sdk-internals/communicator/winrm 0.114s
ok      github.com/hashicorp/packer-plugin-sdk/shell    0.054s
ok      github.com/hashicorp/packer-plugin-sdk/shell-local      0.118s
ok      github.com/hashicorp/packer-plugin-sdk/shell-local/localexec    0.093s
ok      github.com/hashicorp/packer-plugin-sdk/shutdowncommand  0.060s
ok      github.com/hashicorp/packer-plugin-sdk/template 0.120s
ok      github.com/hashicorp/packer-plugin-sdk/template/config  0.094s
ok      github.com/hashicorp/packer-plugin-sdk/template/interpolate     0.118s
ok      github.com/hashicorp/packer-plugin-sdk/template/interpolate/aws/secretsmanager  0.096s
ok      github.com/hashicorp/packer-plugin-sdk/useragent        0.094s
ok      github.com/hashicorp/packer-plugin-sdk/uuid     0.111s
ok      github.com/hashicorp/packer-plugin-sdk/version  0.094s
```