### PR TITLE
add HTTPCallbackAddress, needed when running within a kubernetes cluster

### DIFF
--- a/multistep/commonsteps/http_config.go
+++ b/multistep/commonsteps/http_config.go
@@ -54,6 +54,9 @@ type HTTPConfig struct {
 	// This is the bind address for the HTTP server. Defaults to 0.0.0.0 so that
 	// it will work with any network interface.
 	HTTPAddress string `mapstructure:"http_bind_address"`
+	// Use to specify a specific ip/fqdn a vm should use to reach the callback http server upon completion.
+	// This is required when running via workflows/pipelines which are running within a kubernetes cluster.
+	HTTPCallbackAddress string `mapstructure:"http_callback_address"`
 	// This is the bind interface for the HTTP server. Defaults to the first
 	// interface with a non-loopback address. Either `http_bind_address` or
 	// `http_interface` can be specified.


### PR DESCRIPTION
Describe the change you are making here!

When running within a kubernetes workflow/pipelines, the http server used by the vm to communicate back completion cannot be reached directly.  Instead, with kubernetes you 'expose' a pod via a LoadBalancer ip or ingress.  The exposed ip is available but must be passed in somehow in order for it to be used.

This pull request adds a variable HTTPCallbackAddress, which if provided, can be used by a provider to pass the needed ip to the vm.

Another pull request will be submitted on the packer-plugin-proxmox as a first candidate once this change is in place (which will resolve https://github.com/hashicorp/packer-plugin-proxmox/issues/304).

There must also be template source code for those who are looking to create a provider.  Such templated code should be updated also, eventually.  I will look to do that later on.

Please include tests. Check out existent tests in the code for example.

The only test would be to see if the variable ends up in the config.hcl2spec.go .  I suspect there already exist tests which test mapstructure-to-hcl2.

If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes #264
