### PR TITLE
Support raw/plain secret pull from AWS Secret Manager

### DIFF
--- a/template/funcs.go
+++ b/template/funcs.go
@@ -117,5 +117,25 @@ func GetAWSSecret(name, key string) (string, error) {
 		Key:  key,
 	}
 
-	return client.GetSecret(spec)
+	return client.GetSecret(spec, false)
+}
+
+func GetRawAWSSecret(name string) (string, error) {
+	if len(name) == 0 {
+		return "", errors.New("At least one secret name must be provided")
+	}
+
+	// client uses AWS SDK CredentialChain method. So,credentials can
+	// be loaded from credential file, environment variables, or IAM
+	// roles.
+	client := awssmapi.New(
+		&awssmapi.AWSConfig{},
+	)
+
+	spec := &awssmapi.SecretSpec{
+		Name: name,
+		Key:  "",
+	}
+
+	return client.GetSecret(spec, true)
 }

--- a/template/interpolate/aws/secretsmanager/secretsmanager.go
+++ b/template/interpolate/aws/secretsmanager/secretsmanager.go
@@ -52,7 +52,7 @@ func (c *Client) newSession(config *AWSConfig) *session.Session {
 
 // GetSecret return an AWS Secret Manager secret
 // in plain text from a given secret name
-func (c *Client) GetSecret(spec *SecretSpec) (string, error) {
+func (c *Client) GetSecret(spec *SecretSpec, raw bool) (string, error) {
 	params := &secretsmanager.GetSecretValueInput{
 		SecretId:     aws.String(spec.Name),
 		VersionStage: aws.String("AWSCURRENT"),
@@ -71,7 +71,7 @@ func (c *Client) GetSecret(spec *SecretSpec) (string, error) {
 		Name:         *resp.Name,
 		SecretString: *resp.SecretString,
 	}
-	value, err := getSecretValue(&secret, spec)
+	value, err := getSecretValue(&secret, spec, raw)
 	if err != nil {
 		return "", err
 	}
@@ -79,12 +79,12 @@ func (c *Client) GetSecret(spec *SecretSpec) (string, error) {
 	return value, nil
 }
 
-func getSecretValue(s *SecretString, spec *SecretSpec) (string, error) {
+func getSecretValue(s *SecretString, spec *SecretSpec, raw bool) (string, error) {
 	var secretValue map[string]interface{}
 	blob := []byte(s.SecretString)
 
-	//For those plaintext secrets just return the value
-	if !json.Valid(blob) {
+	//For those plaintext secrets just return the value or if raw is requested
+	if !json.Valid(blob) || raw {
 		return s.SecretString, nil
 	}
 

--- a/template/interpolate/funcs.go
+++ b/template/interpolate/funcs.go
@@ -30,23 +30,24 @@ func init() {
 
 // Funcs are the interpolation funcs that are available within interpolations.
 var FuncGens = map[string]interface{}{
-	"build_name":         funcGenBuildName,
-	"build_type":         funcGenBuildType,
-	"env":                funcGenEnv,
-	"isotime":            funcGenIsotime,
-	"strftime":           funcGenStrftime,
-	"pwd":                funcGenPwd,
-	"split":              funcGenSplitter,
-	"template_dir":       funcGenTemplateDir,
-	"timestamp":          funcGenTimestamp,
-	"uuid":               funcGenUuid,
-	"user":               funcGenUser,
-	"packer_version":     funcGenPackerVersion,
-	"consul_key":         funcGenConsul,
-	"vault":              funcGenVault,
-	"sed":                funcGenSed,
-	"build":              funcGenBuild,
-	"aws_secretsmanager": funcGenAwsSecrets,
+	"build_name":             funcGenBuildName,
+	"build_type":             funcGenBuildType,
+	"env":                    funcGenEnv,
+	"isotime":                funcGenIsotime,
+	"strftime":               funcGenStrftime,
+	"pwd":                    funcGenPwd,
+	"split":                  funcGenSplitter,
+	"template_dir":           funcGenTemplateDir,
+	"timestamp":              funcGenTimestamp,
+	"uuid":                   funcGenUuid,
+	"user":                   funcGenUser,
+	"packer_version":         funcGenPackerVersion,
+	"consul_key":             funcGenConsul,
+	"vault":                  funcGenVault,
+	"sed":                    funcGenSed,
+	"build":                  funcGenBuild,
+	"aws_secretsmanager":     funcGenAwsSecrets,
+	"aws_secretsmanager_raw": funcGenAwsRawSecrets,
 
 	"replace":     replace,
 	"replace_all": replace_all,
@@ -295,6 +296,22 @@ func funcGenAwsSecrets(ctx *Context) interface{} {
 		default:
 			return "", errors.New("only secret name and optional secret key can be provided.")
 		}
+	}
+}
+
+// This function acts essentially like `funcGenAwsSecrets`, with the exception
+// that it will always return a plaintext secret, regardless of the type of
+// secret.
+//
+// That is, if the secret is a plaintext, both functions behave the same,
+// however, if the secret is an object, this will return the raw JSON object
+// from secrets manager, while the alternative errors without a key being specified.
+func funcGenAwsRawSecrets(ctx *Context) interface{} {
+	return func(secretName string) (string, error) {
+		if !ctx.EnableEnv {
+			return "", errors.New("AWS Secrets Manager is only allowed in the variables section")
+		}
+		return commontpl.GetRawAWSSecret(secretName)
 	}
 }
 


### PR DESCRIPTION
Hi Packer community!

This PR solves the issue described in [Packer Issue ](https://github.com/hashicorp/packer/issues/13112). Currently, the secret manager is only able to work with simple `key:value` pairs in JSON format. This is unfortunate as there are other types of secrets in the world.

In this PR, I have added an additional argument to secretsmanager, which allows you to select whether you want the secret in raw/plain form or in the default `key:value` pair format.

Essentially, the only change is that the `awsmanager` function `GetSecret()` now takes one additional argument `raw`, which is a simple boolean. This boolean instructs the function to return the plain string value of the secret even if the secret is valid JSON.

There are two tests implemented for this feature. If you are still unsure about the issue, please take a look at the tests. I think it will be quite clear after that.

Of course, to expose this feature, we will also have to add a new function to Packer that will fully expose this to users.

As this is my first contribution to Packer/Packer SDK, I am glad for all the feedback and advice on how to push this PR forward.