### PR TITLE
fixes for packer_acc_tests for windows 

### DIFF
--- a/acctest/provisioneracc/test-fixtures/amazon-ebs/amazon-ebs_windows.txt
+++ b/acctest/provisioneracc/test-fixtures/amazon-ebs/amazon-ebs_windows.txt
@@ -5,7 +5,7 @@
   "source_ami_filter": {
     "filters": {
       "virtualization-type": "hvm",
-      "name": "*Windows_Server-2012-R2*English-64Bit-Base*",
+      "name": "*Windows_Server-2022-English-Core-Base*",
       "root-device-type": "ebs"
     },
     "most_recent": true,

--- a/acctest/provisioneracc/test-fixtures/amazon-ebs/amazon-ebs_windows.txt
+++ b/acctest/provisioneracc/test-fixtures/amazon-ebs/amazon-ebs_windows.txt
@@ -12,7 +12,7 @@
     "owners": "amazon"
   },
   "ami_name": "packer-acc-test",
-  "user_data_file": "../../builder/amazon/ebs/acceptance/test-fixtures/scripts/bootstrap_win.txt",
+  "user_data_file": "../scripts/bootstrap_win.txt",
   "communicator": "winrm",
   "winrm_username": "Administrator",
   "winrm_password": "SuperS3cr3t!!!!",

--- a/acctest/provisioneracc/test-fixtures/amazon-ebs/amazon-ebs_windows.txt
+++ b/acctest/provisioneracc/test-fixtures/amazon-ebs/amazon-ebs_windows.txt
@@ -12,7 +12,7 @@
     "owners": "amazon"
   },
   "ami_name": "packer-acc-test",
-  "user_data_file": "../scripts/bootstrap_win.txt",
+  "user_data_file": "../../provisioner/powershell/test-fixtures/scripts/bootstrap_win.txt",
   "communicator": "winrm",
   "winrm_username": "Administrator",
   "winrm_password": "SuperS3cr3t!!!!",

--- a/acctest/provisioneracc/test-fixtures/amazon-ebs/amazon-ebs_windows.txt
+++ b/acctest/provisioneracc/test-fixtures/amazon-ebs/amazon-ebs_windows.txt
@@ -17,6 +17,7 @@
   "winrm_username": "Administrator",
   "winrm_password": "SuperS3cr3t!!!!",
   "force_deregister" : true,
+  "skip_create_ami": true,
   "tags": {
     "packer-test": "true"
   }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hashicorp/packer-plugin-sdk
+module github.com/kp2099/packer-plugin-sdk
 
 require github.com/zclconf/go-cty v1.13.3 // go-cty v1.11.0 removed gob encoding support so it cannot work with the Packer SDK as-is, you need to run `packer-sdc fix .' to change that
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kp2099/packer-plugin-sdk
+module github.com/hashicorp/packer-plugin-sdk
 
 require github.com/zclconf/go-cty v1.13.3 // go-cty v1.11.0 removed gob encoding support so it cannot work with the Packer SDK as-is, you need to run `packer-sdc fix .' to change that
 


### PR DESCRIPTION
Changing the path here to reference it to the bootstrap_win.txt file thats been added here (https://github.com/hashicorp/packer/pull/13334)

Currently i believe the acceptance tests fail with "user_data_file" not found.

Also adding skip_create_ami to not create an AMI when running acceptance tests