### PR TITLE
Added Documentaion Comments for SSH Tunnel flags

### DIFF
--- a/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/SSH-not-required.mdx
+++ b/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/SSH-not-required.mdx
@@ -95,8 +95,12 @@
   useful if, for example, packer hangs on a connection after a reboot.
   Example: `5m`. Disabled by default.
 
-- `ssh_remote_tunnels` ([]string) - 
+- `ssh_remote_tunnels` ([]string) - Remote tunnels forward a port from your local machine to the instance.
+  Format: ["REMOTE_PORT:LOCAL_HOST:LOCAL_PORT"]
+  Example: "9090:localhost:80" forwards localhost:9090 on your machine to port 80 on the instance.
 
-- `ssh_local_tunnels` ([]string) - 
+- `ssh_local_tunnels` ([]string) - Local tunnels forward a port from the instance to your local machine.
+  Format: ["LOCAL_PORT:REMOTE_HOST:REMOTE_PORT"]
+  Example: "8080:localhost:3000" allows the instance to access your local machine’s port 3000 via localhost:8080.
 
 <!-- End of code generated from the comments of the SSH struct in communicator/config.go; -->

--- a/communicator/config.go
+++ b/communicator/config.go
@@ -188,9 +188,14 @@ type SSH struct {
 
 	// Tunneling
 
-	//
+	// Remote tunnels forward a port from your local machine to the instance.
+	// Format: ["REMOTE_PORT:LOCAL_HOST:LOCAL_PORT"]
+	// Example: "9090:localhost:80" forwards localhost:9090 on your machine to port 80 on the instance.
 	SSHRemoteTunnels []string `mapstructure:"ssh_remote_tunnels"`
-	//
+
+	// Local tunnels forward a port from the instance to your local machine.
+	// Format: ["LOCAL_PORT:REMOTE_HOST:REMOTE_PORT"]
+	// Example: "8080:localhost:3000" allows the instance to access your local machine’s port 3000 via localhost:8080.
 	SSHLocalTunnels []string `mapstructure:"ssh_local_tunnels"`
 
 	// SSH Internals


### PR DESCRIPTION
Added missing documentation for the ssh_remote_tunnels and ssh_local_tunnels flags.