### PR TITLE
multistep: use go doc comment syntax

### DIFF
--- a/multistep/doc.go
+++ b/multistep/doc.go
@@ -7,13 +7,12 @@ individual "steps." These steps are strung together and run in sequence
 to achieve a more complex goal. The runner handles cleanup, cancelling, etc.
 if necessary.
 
-## Basic Example
+# Basic Example
 
 Make a step to perform some action. The step can access your "state",
 which is passed between steps by the runner.
 
-```go
-type stepAdd struct{}
+	type stepAdd struct{}
 
 	func (s *stepAdd) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	    // Read our value and assert that it is they type we want
@@ -30,11 +29,7 @@ type stepAdd struct{}
 		// cancelled so that cleanup can be performed.
 	}
 
-```
-
 Make a runner and call your array of Steps.
-
-```go
 
 	func main() {
 	    // Our "bag of state" that we read the value from
@@ -53,14 +48,10 @@ Make a runner and call your array of Steps.
 	    runner.Run(context.Background(), state)
 	}
 
-```
-
 This will produce:
 
-```
-Value is 0
-Value is 1
-Value is 2
-```
+	Value is 0
+	Value is 1
+	Value is 2
 */
 package multistep


### PR DESCRIPTION
Updated the `doc.go` file to adhere to [Go Doc Comment](https://go.dev/doc/comment) syntax. This allows the documentation to render correctly on `pkg.go.dev`.

I was reading the `multistep` package documentation when I noticed this. Perhaps there are more packages that need updating but I didn't enumerate them.

## Before

![Screenshot From 2025-04-14 15-50-19](https://github.com/user-attachments/assets/d6a326ea-cccc-4ce9-b3f5-a61c692d2807)

## After

![Screenshot From 2025-04-14 15-50-24](https://github.com/user-attachments/assets/5933fc50-acdc-4f73-9559-02c15cea113b)
