### PR TITLE
Removing the Message method from UI Interface

### DIFF
--- a/chroot/step_copy_files.go
+++ b/chroot/step_copy_files.go
@@ -47,7 +47,7 @@ func (s *StepCopyFiles) Run(ctx context.Context, state multistep.StateBag) multi
 			removeDestinationOption = "--remove-destination"
 		}
 		for _, path := range s.Files {
-			ui.Message(path)
+			ui.Say(path)
 			chrootPath := filepath.Join(mountPath, path)
 			log.Printf("Copying '%s' to '%s'", path, chrootPath)
 

--- a/chroot/step_mount_extra.go
+++ b/chroot/step_mount_extra.go
@@ -49,7 +49,7 @@ func (s *StepMountExtra) Run(ctx context.Context, state multistep.StateBag) mult
 			flags = "--bind"
 		}
 
-		ui.Message(fmt.Sprintf("Mounting: %s", mountInfo[2]))
+		ui.Say(fmt.Sprintf("Mounting: %s", mountInfo[2]))
 		stderr := new(bytes.Buffer)
 		mountCommand, err := wrappedCommand(fmt.Sprintf(
 			"mount %s %s %s",

--- a/communicator/step_debug_ssh_keys.go
+++ b/communicator/step_debug_ssh_keys.go
@@ -22,7 +22,7 @@ type StepDumpSSHKey struct {
 func (s *StepDumpSSHKey) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packersdk.Ui)
 
-	ui.Message(fmt.Sprintf("Saving key for debug purposes: %s", s.Path))
+	ui.Say(fmt.Sprintf("Saving key for debug purposes: %s", s.Path))
 
 	err := os.WriteFile(s.Path, s.SSH.SSHPrivateKey, 0700)
 	if err != nil {

--- a/multistep/commonsteps/step_create_cdrom.go
+++ b/multistep/commonsteps/step_create_cdrom.go
@@ -104,7 +104,7 @@ func (s *StepCreateCD) Run(ctx context.Context, state multistep.StateBag) multis
 		return multistep.ActionHalt
 	}
 
-	ui.Message("Done copying paths from CD_dirs")
+	ui.Say("Done copying paths from CD_dirs")
 
 	// Set the path to the CD so it can be used later
 	state.Put("cd_path", CDPath)

--- a/multistep/commonsteps/step_create_floppy.go
+++ b/multistep/commonsteps/step_create_floppy.go
@@ -132,7 +132,7 @@ func (s *StepCreateFloppy) Run(ctx context.Context, state multistep.StateBag) mu
 		}
 		if !info.IsDir() {
 			crawlDirectoryFiles = append(crawlDirectoryFiles, path)
-			ui.Message(fmt.Sprintf("Adding file: %s", path))
+			ui.Say(fmt.Sprintf("Adding file: %s", path))
 		}
 		return nil
 	}
@@ -142,7 +142,7 @@ func (s *StepCreateFloppy) Run(ctx context.Context, state multistep.StateBag) mu
 	var filelist = make(chan string)
 	go globFiles(s.Files, filelist)
 
-	ui.Message("Copying files flatly from floppy_files")
+	ui.Say("Copying files flatly from floppy_files")
 	for {
 		filename, ok := <-filelist
 		if !ok {
@@ -157,7 +157,7 @@ func (s *StepCreateFloppy) Run(ctx context.Context, state multistep.StateBag) mu
 
 		// walk through directory adding files to the root of the fs
 		if finfo.IsDir() {
-			ui.Message(fmt.Sprintf("Copying directory: %s", filename))
+			ui.Say(fmt.Sprintf("Copying directory: %s", filename))
 
 			err := filepath.Walk(filename, crawlDirectory)
 			if err != nil {
@@ -178,17 +178,17 @@ func (s *StepCreateFloppy) Run(ctx context.Context, state multistep.StateBag) mu
 		}
 
 		// add just a single file
-		ui.Message(fmt.Sprintf("Copying file: %s", filename))
+		ui.Say(fmt.Sprintf("Copying file: %s", filename))
 		if err = s.Add(cache, filename); err != nil {
 			state.Put("error", fmt.Errorf("Error adding file from floppy_files : %s : %s", filename, err))
 			return multistep.ActionHalt
 		}
 		s.FilesAdded[filename] = true
 	}
-	ui.Message("Done copying files from floppy_files")
+	ui.Say("Done copying files from floppy_files")
 
 	// Collect all paths (expanding wildcards) into pathqueue
-	ui.Message("Collecting paths from floppy_dirs")
+	ui.Say("Collecting paths from floppy_dirs")
 	var pathqueue []string
 	for _, filename := range s.Directories {
 		if strings.ContainsAny(filename, "*?[") {
@@ -203,21 +203,21 @@ func (s *StepCreateFloppy) Run(ctx context.Context, state multistep.StateBag) mu
 		}
 		pathqueue = append(pathqueue, filename)
 	}
-	ui.Message(fmt.Sprintf("Resulting paths from floppy_dirs : %v", pathqueue))
+	ui.Say(fmt.Sprintf("Resulting paths from floppy_dirs : %v", pathqueue))
 
 	// Go over each path in pathqueue and copy it.
 	for _, src := range pathqueue {
-		ui.Message(fmt.Sprintf("Recursively copying : %s", src))
+		ui.Say(fmt.Sprintf("Recursively copying : %s", src))
 		err = s.Add(cache, src)
 		if err != nil {
 			state.Put("error", fmt.Errorf("Error adding path %s to floppy: %s", src, err))
 			return multistep.ActionHalt
 		}
 	}
-	ui.Message("Done copying paths from floppy_dirs")
+	ui.Say("Done copying paths from floppy_dirs")
 
 	// Collect files from floppy_content
-	ui.Message("Copying files from floppy_content")
+	ui.Say("Copying files from floppy_content")
 	for path, content := range s.Content {
 		err = s.AddContent(cache, path, content)
 		if err != nil {
@@ -226,7 +226,7 @@ func (s *StepCreateFloppy) Run(ctx context.Context, state multistep.StateBag) mu
 			return multistep.ActionHalt
 		}
 	}
-	ui.Message("Done copying files from floppy_content")
+	ui.Say("Done copying files from floppy_content")
 
 	// Set the path to the floppy so it can be used later
 	state.Put("floppy_path", s.floppyPath)

--- a/packer/communicator.go
+++ b/packer/communicator.go
@@ -149,7 +149,7 @@ OutputLoop:
 			}
 		case output := <-stdoutCh:
 			if output != "" {
-				ui.Message(r.cleanOutputLine(output))
+				ui.Say(r.cleanOutputLine(output))
 			}
 		case <-r.exitCh:
 			break OutputLoop
@@ -161,7 +161,7 @@ OutputLoop:
 	// Make sure we finish off stdout/stderr because we may have gotten
 	// a message from the exit channel before finishing these first.
 	for output := range stdoutCh {
-		ui.Message(r.cleanOutputLine(output))
+		ui.Say(r.cleanOutputLine(output))
 	}
 
 	for output := range stderrCh {

--- a/packer/ui.go
+++ b/packer/ui.go
@@ -30,7 +30,6 @@ type Ui interface {
 	Askf(string, ...any) (string, error)
 	Say(string)
 	Sayf(string, ...any)
-	Message(string)
 	Error(string)
 	Errorf(string, ...any)
 	Machine(string, ...string)
@@ -124,20 +123,6 @@ func (rw *BasicUi) Say(message string) {
 	}
 }
 
-func (rw *BasicUi) Message(message string) {
-	rw.l.Lock()
-	defer rw.l.Unlock()
-
-	// Use LogSecretFilter to scrub out sensitive variables
-	message = LogSecretFilter.FilterString(message)
-
-	log.Printf("ui: %s", message)
-	_, err := fmt.Fprint(rw.Writer, message+"\n")
-	if err != nil {
-		log.Printf("[ERR] Failed to write to UI: %s", err)
-	}
-}
-
 func (rw *BasicUi) Errorf(message string, args ...any) {
 	rw.Error(fmt.Sprintf(message, args...))
 }
@@ -202,12 +187,6 @@ func (u *SafeUi) Sayf(s string, args ...any) {
 func (u *SafeUi) Say(s string) {
 	u.Sem <- 1
 	u.Ui.Say(s)
-	<-u.Sem
-}
-
-func (u *SafeUi) Message(s string) {
-	u.Sem <- 1
-	u.Ui.Message(s)
 	<-u.Sem
 }
 

--- a/packer/ui_mock.go
+++ b/packer/ui_mock.go
@@ -29,17 +29,15 @@ type SayMessage struct {
 }
 
 type MockUi struct {
-	AskCalled      bool
-	AskQuery       string
-	ErrorCalled    bool
-	ErrorMessage   string
-	MachineCalled  bool
-	MachineType    string
-	MachineArgs    []string
-	MessageCalled  bool
-	MessageMessage string
-	SayCalled      bool
-	SayMessages    []SayMessage
+	AskCalled     bool
+	AskQuery      string
+	ErrorCalled   bool
+	ErrorMessage  string
+	MachineCalled bool
+	MachineType   string
+	MachineArgs   []string
+	SayCalled     bool
+	SayMessages   []SayMessage
 
 	TrackProgressCalled    bool
 	ProgressBarAddCalled   bool
@@ -67,11 +65,6 @@ func (u *MockUi) Machine(t string, args ...string) {
 	u.MachineCalled = true
 	u.MachineType = t
 	u.MachineArgs = args
-}
-
-func (u *MockUi) Message(message string) {
-	u.MessageCalled = true
-	u.MessageMessage = message
 }
 
 func (u *MockUi) Sayf(message string, args ...any) {

--- a/rpc/ui.go
+++ b/rpc/ui.go
@@ -60,12 +60,6 @@ func (u *Ui) Machine(t string, args ...string) {
 	}
 }
 
-func (u *Ui) Message(message string) {
-	if err := u.client.Call("Ui.Message", message, new(interface{})); err != nil {
-		log.Printf("Error in Ui.Message RPC call: %s", err)
-	}
-}
-
 func (u *Ui) Sayf(message string, args ...any) {
 	u.Say(fmt.Sprintf(message, args...))
 }
@@ -90,12 +84,6 @@ func (u *UiServer) Error(message *string, reply *interface{}) error {
 func (u *UiServer) Machine(args *UiMachineArgs, reply *interface{}) error {
 	u.ui.Machine(args.Category, args.Args...)
 
-	*reply = nil
-	return nil
-}
-
-func (u *UiServer) Message(message *string, reply *interface{}) error {
-	u.ui.Message(*message)
 	*reply = nil
 	return nil
 }

--- a/rpc/ui_test.go
+++ b/rpc/ui_test.go
@@ -52,11 +52,6 @@ func (u *testUi) Machine(t string, args ...string) {
 	u.machineArgs = args
 }
 
-func (u *testUi) Message(message string) {
-	u.messageCalled = true
-	u.messageMessage = message
-}
-
 func (u *testUi) Sayf(message string, args ...any) {
 	u.Say(fmt.Sprintf(message, args...))
 }
@@ -117,11 +112,6 @@ func TestUiRPC(t *testing.T) {
 
 	uiClient.Error("message")
 	if ui.errorMessage != "message" {
-		t.Fatalf("bad: %#v", ui.errorMessage)
-	}
-
-	uiClient.Message("message")
-	if ui.messageMessage != "message" {
 		t.Fatalf("bad: %#v", ui.errorMessage)
 	}
 

--- a/shell-local/localexec/run_and_stream.go
+++ b/shell-local/localexec/run_and_stream.go
@@ -75,7 +75,7 @@ func RunAndStream(cmd *exec.Cmd, ui packersdk.Ui, sensitive []string) error {
 		for data := range ch {
 			data = cleanOutputLine(data)
 			if data != "" {
-				ui.Message(data)
+				ui.Say(data)
 			}
 		}
 	}


### PR DESCRIPTION
Removed the `Message` method from the cli UI interface to simplify the logs and replacing them with the `Say` method.