### PR TITLE
Deprecating `Message` method in UI interface

### DIFF
--- a/packer/ui.go
+++ b/packer/ui.go
@@ -30,6 +30,7 @@ type Ui interface {
 	Askf(string, ...any) (string, error)
 	Say(string)
 	Sayf(string, ...any)
+	// Deprecated: Use `Say` instead.
 	Message(string)
 	Error(string)
 	Errorf(string, ...any)
@@ -124,18 +125,9 @@ func (rw *BasicUi) Say(message string) {
 	}
 }
 
+// Deprecated: Use `Say` instead.
 func (rw *BasicUi) Message(message string) {
-	rw.l.Lock()
-	defer rw.l.Unlock()
-
-	// Use LogSecretFilter to scrub out sensitive variables
-	message = LogSecretFilter.FilterString(message)
-
-	log.Printf("ui: %s", message)
-	_, err := fmt.Fprint(rw.Writer, message+"\n")
-	if err != nil {
-		log.Printf("[ERR] Failed to write to UI: %s", err)
-	}
+	rw.Say(message)
 }
 
 func (rw *BasicUi) Errorf(message string, args ...any) {

--- a/packer/ui_mock.go
+++ b/packer/ui_mock.go
@@ -69,9 +69,9 @@ func (u *MockUi) Machine(t string, args ...string) {
 	u.MachineArgs = args
 }
 
+// Deprecated: Use `Say` instead.
 func (u *MockUi) Message(message string) {
-	u.MessageCalled = true
-	u.MessageMessage = message
+	u.Say(message)
 }
 
 func (u *MockUi) Sayf(message string, args ...any) {

--- a/rpc/ui.go
+++ b/rpc/ui.go
@@ -60,6 +60,7 @@ func (u *Ui) Machine(t string, args ...string) {
 	}
 }
 
+// Deprecated: Use `Say` instead.
 func (u *Ui) Message(message string) {
 	if err := u.client.Call("Ui.Message", message, new(interface{})); err != nil {
 		log.Printf("Error in Ui.Message RPC call: %s", err)
@@ -94,6 +95,7 @@ func (u *UiServer) Machine(args *UiMachineArgs, reply *interface{}) error {
 	return nil
 }
 
+// Deprecated: Use `Say` instead.
 func (u *UiServer) Message(message *string, reply *interface{}) error {
 	u.ui.Message(*message)
 	*reply = nil

--- a/rpc/ui_test.go
+++ b/rpc/ui_test.go
@@ -52,6 +52,7 @@ func (u *testUi) Machine(t string, args ...string) {
 	u.machineArgs = args
 }
 
+// Deprecated: Use `Say` instead.
 func (u *testUi) Message(message string) {
 	u.messageCalled = true
 	u.messageMessage = message


### PR DESCRIPTION
Deprecating the `Message` method from the cli UI interface to simplify the logs and replacing them with the Say method.