### PR TITLE
fixing acceptance tests for shell and shell-local.

### DIFF
--- a/acctest/provisioneracc/test-fixtures/amazon-ebs/amazon-ebs.txt
+++ b/acctest/provisioneracc/test-fixtures/amazon-ebs/amazon-ebs.txt
@@ -7,12 +7,13 @@
   "source_ami_filter": {
     "filters": {
       "virtualization-type": "hvm",
-      "name": "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*",
+      "name": "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*",
       "root-device-type": "ebs"
     },
     "owners": ["099720109477"],
     "most_recent": true
   },
+  "skip_create_ami": true,
   "force_deregister" : true,
   "tags": {
     "packer-test": "true"


### PR DESCRIPTION
Packer daily acceptance tests were failing because the AMI filter was failing to resolve into a valid AMI. Updating the filter to use a more recent image.

Additionally setting `skip_create_ami=true`, to avoid building the AMI during acceptance testing

