### PR TITLE
feat: add winrm connect timeout and retry params

### DIFF
--- a/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/WinRM-not-required.mdx
+++ b/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/WinRM-not-required.mdx
@@ -22,6 +22,12 @@
 - `winrm_timeout` (duration string | ex: "1h5m2s") - The amount of time to wait for WinRM to become available. This defaults
   to `30m` since setting up a Windows machine generally takes a long time.
 
+- `winrm_retry_interval` (duration string | ex: "1h5m2s") - The amount of time to wait between retries when attempting to
+  connect to WinRM. This defaults to `5s`.
+
+- `winrm_connect_timeout` (duration string | ex: "1h5m2s") - The timeout for each individual WinRM connection attempt. This
+  defaults to `0` (no per-attempt timeout; each attempt waits until the server responds or resets the connection).
+
 - `winrm_use_ssl` (bool) - If `true`, use HTTPS for WinRM.
 
 - `winrm_insecure` (bool) - If `true`, do not check server certificate chain and host name.

--- a/communicator/config.go
+++ b/communicator/config.go
@@ -252,6 +252,13 @@ type WinRM struct {
 	// The amount of time to wait for WinRM to become available. This defaults
 	// to `30m` since setting up a Windows machine generally takes a long time.
 	WinRMTimeout time.Duration `mapstructure:"winrm_timeout"`
+	// The amount of time to wait between retries when attempting to connect to
+	// WinRM. This defaults to `5s`.
+	WinRMRetryInterval time.Duration `mapstructure:"winrm_retry_interval"`
+	// The timeout for each individual WinRM connection attempt. This defaults
+	// to `0` (no per-attempt timeout; each attempt waits until the server
+	// responds or resets the connection).
+	WinRMConnectTimeout time.Duration `mapstructure:"winrm_connect_timeout"`
 	// If `true`, use HTTPS for WinRM.
 	WinRMUseSSL bool `mapstructure:"winrm_use_ssl"`
 	// If `true`, do not check server certificate chain and host name.
@@ -633,6 +640,10 @@ func (c *Config) prepareWinRM(ctx *interpolate.Context) (errs []error) {
 
 	if c.WinRMTimeout == 0 {
 		c.WinRMTimeout = 30 * time.Minute
+	}
+
+	if c.WinRMRetryInterval == 0 {
+		c.WinRMRetryInterval = 5 * time.Second
 	}
 
 	if c.WinRMUseNTLM.True() {

--- a/communicator/config.hcl2spec.go
+++ b/communicator/config.hcl2spec.go
@@ -56,6 +56,8 @@ type FlatConfig struct {
 	WinRMNoProxy              *bool    `mapstructure:"winrm_no_proxy" cty:"winrm_no_proxy" hcl:"winrm_no_proxy"`
 	WinRMPort                 *int     `mapstructure:"winrm_port" cty:"winrm_port" hcl:"winrm_port"`
 	WinRMTimeout              *string  `mapstructure:"winrm_timeout" cty:"winrm_timeout" hcl:"winrm_timeout"`
+	WinRMRetryInterval        *string  `mapstructure:"winrm_retry_interval" cty:"winrm_retry_interval" hcl:"winrm_retry_interval"`
+	WinRMConnectTimeout       *string  `mapstructure:"winrm_connect_timeout" cty:"winrm_connect_timeout" hcl:"winrm_connect_timeout"`
 	WinRMUseSSL               *bool    `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl" hcl:"winrm_use_ssl"`
 	WinRMInsecure             *bool    `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
 	WinRMUseNTLM              *bool    `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
@@ -119,6 +121,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_no_proxy":               &hcldec.AttrSpec{Name: "winrm_no_proxy", Type: cty.Bool, Required: false},
 		"winrm_port":                   &hcldec.AttrSpec{Name: "winrm_port", Type: cty.Number, Required: false},
 		"winrm_timeout":                &hcldec.AttrSpec{Name: "winrm_timeout", Type: cty.String, Required: false},
+		"winrm_retry_interval":         &hcldec.AttrSpec{Name: "winrm_retry_interval", Type: cty.String, Required: false},
+		"winrm_connect_timeout":        &hcldec.AttrSpec{Name: "winrm_connect_timeout", Type: cty.String, Required: false},
 		"winrm_use_ssl":                &hcldec.AttrSpec{Name: "winrm_use_ssl", Type: cty.Bool, Required: false},
 		"winrm_insecure":               &hcldec.AttrSpec{Name: "winrm_insecure", Type: cty.Bool, Required: false},
 		"winrm_use_ntlm":               &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
@@ -251,15 +255,17 @@ func (*FlatSSHTemporaryKeyPair) HCL2Spec() map[string]hcldec.Spec {
 // FlatWinRM is an auto-generated flat version of WinRM.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatWinRM struct {
-	WinRMUser     *string `mapstructure:"winrm_username" cty:"winrm_username" hcl:"winrm_username"`
-	WinRMPassword *string `mapstructure:"winrm_password" cty:"winrm_password" hcl:"winrm_password"`
-	WinRMHost     *string `mapstructure:"winrm_host" cty:"winrm_host" hcl:"winrm_host"`
-	WinRMNoProxy  *bool   `mapstructure:"winrm_no_proxy" cty:"winrm_no_proxy" hcl:"winrm_no_proxy"`
-	WinRMPort     *int    `mapstructure:"winrm_port" cty:"winrm_port" hcl:"winrm_port"`
-	WinRMTimeout  *string `mapstructure:"winrm_timeout" cty:"winrm_timeout" hcl:"winrm_timeout"`
-	WinRMUseSSL   *bool   `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl" hcl:"winrm_use_ssl"`
-	WinRMInsecure *bool   `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
-	WinRMUseNTLM  *bool   `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
+	WinRMUser           *string `mapstructure:"winrm_username" cty:"winrm_username" hcl:"winrm_username"`
+	WinRMPassword       *string `mapstructure:"winrm_password" cty:"winrm_password" hcl:"winrm_password"`
+	WinRMHost           *string `mapstructure:"winrm_host" cty:"winrm_host" hcl:"winrm_host"`
+	WinRMNoProxy        *bool   `mapstructure:"winrm_no_proxy" cty:"winrm_no_proxy" hcl:"winrm_no_proxy"`
+	WinRMPort           *int    `mapstructure:"winrm_port" cty:"winrm_port" hcl:"winrm_port"`
+	WinRMTimeout        *string `mapstructure:"winrm_timeout" cty:"winrm_timeout" hcl:"winrm_timeout"`
+	WinRMRetryInterval  *string `mapstructure:"winrm_retry_interval" cty:"winrm_retry_interval" hcl:"winrm_retry_interval"`
+	WinRMConnectTimeout *string `mapstructure:"winrm_connect_timeout" cty:"winrm_connect_timeout" hcl:"winrm_connect_timeout"`
+	WinRMUseSSL         *bool   `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl" hcl:"winrm_use_ssl"`
+	WinRMInsecure       *bool   `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
+	WinRMUseNTLM        *bool   `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
 }
 
 // FlatMapstructure returns a new FlatWinRM.
@@ -274,15 +280,17 @@ func (*WinRM) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } 
 // The decoded values from this spec will then be applied to a FlatWinRM.
 func (*FlatWinRM) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"winrm_username": &hcldec.AttrSpec{Name: "winrm_username", Type: cty.String, Required: false},
-		"winrm_password": &hcldec.AttrSpec{Name: "winrm_password", Type: cty.String, Required: false},
-		"winrm_host":     &hcldec.AttrSpec{Name: "winrm_host", Type: cty.String, Required: false},
-		"winrm_no_proxy": &hcldec.AttrSpec{Name: "winrm_no_proxy", Type: cty.Bool, Required: false},
-		"winrm_port":     &hcldec.AttrSpec{Name: "winrm_port", Type: cty.Number, Required: false},
-		"winrm_timeout":  &hcldec.AttrSpec{Name: "winrm_timeout", Type: cty.String, Required: false},
-		"winrm_use_ssl":  &hcldec.AttrSpec{Name: "winrm_use_ssl", Type: cty.Bool, Required: false},
-		"winrm_insecure": &hcldec.AttrSpec{Name: "winrm_insecure", Type: cty.Bool, Required: false},
-		"winrm_use_ntlm": &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
+		"winrm_username":        &hcldec.AttrSpec{Name: "winrm_username", Type: cty.String, Required: false},
+		"winrm_password":        &hcldec.AttrSpec{Name: "winrm_password", Type: cty.String, Required: false},
+		"winrm_host":            &hcldec.AttrSpec{Name: "winrm_host", Type: cty.String, Required: false},
+		"winrm_no_proxy":        &hcldec.AttrSpec{Name: "winrm_no_proxy", Type: cty.Bool, Required: false},
+		"winrm_port":            &hcldec.AttrSpec{Name: "winrm_port", Type: cty.Number, Required: false},
+		"winrm_timeout":         &hcldec.AttrSpec{Name: "winrm_timeout", Type: cty.String, Required: false},
+		"winrm_retry_interval":  &hcldec.AttrSpec{Name: "winrm_retry_interval", Type: cty.String, Required: false},
+		"winrm_connect_timeout": &hcldec.AttrSpec{Name: "winrm_connect_timeout", Type: cty.String, Required: false},
+		"winrm_use_ssl":         &hcldec.AttrSpec{Name: "winrm_use_ssl", Type: cty.Bool, Required: false},
+		"winrm_insecure":        &hcldec.AttrSpec{Name: "winrm_insecure", Type: cty.Bool, Required: false},
+		"winrm_use_ntlm":        &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/communicator/step_connect_winrm.go
+++ b/communicator/step_connect_winrm.go
@@ -103,7 +103,7 @@ func (s *StepConnectWinRM) waitForWinRM(state multistep.StateBag, ctx context.Co
 			case <-ctx.Done():
 				log.Println("[INFO] WinRM wait cancelled. Exiting loop.")
 				return nil, errors.New("WinRM wait cancelled")
-			case <-time.After(5 * time.Second):
+			case <-time.After(s.Config.WinRMRetryInterval):
 			}
 		}
 		first = false
@@ -163,6 +163,7 @@ func (s *StepConnectWinRM) waitForWinRM(state multistep.StateBag, ctx context.Co
 			Username:           user,
 			Password:           password,
 			Timeout:            s.Config.WinRMTimeout,
+			ConnectTimeout:     s.Config.WinRMConnectTimeout,
 			Https:              s.Config.WinRMUseSSL,
 			Insecure:           s.Config.WinRMInsecure,
 			TransportDecorator: s.Config.WinRMTransportDecorator,
@@ -176,7 +177,7 @@ func (s *StepConnectWinRM) waitForWinRM(state multistep.StateBag, ctx context.Co
 	}
 	// run an "echo" command to make sure winrm is actually connected before moving on.
 	var connectCheckCommand = winrmcmd.Powershell(`if (Test-Path variable:global:ProgressPreference){$ProgressPreference='SilentlyContinue'}; echo "WinRM connected."`)
-	var retryableSleep = 5 * time.Second
+	var retryableSleep = s.Config.WinRMRetryInterval
 	// run an "echo" command to make sure that the winrm is connected
 	for {
 		cmd := &packersdk.RemoteCmd{Command: connectCheckCommand}

--- a/sdk-internals/communicator/winrm/communicator.go
+++ b/sdk-internals/communicator/winrm/communicator.go
@@ -36,6 +36,7 @@ func New(config *Config) (*Communicator, error) {
 		Port:     config.Port,
 		HTTPS:    config.Https,
 		Insecure: config.Insecure,
+		Timeout:  config.ConnectTimeout,
 
 		/*
 			TODO

--- a/sdk-internals/communicator/winrm/config.go
+++ b/sdk-internals/communicator/winrm/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	Username           string
 	Password           string
 	Timeout            time.Duration
+	ConnectTimeout     time.Duration
 	Https              bool
 	Insecure           bool
 	TransportDecorator func() winrm.Transporter


### PR DESCRIPTION
Submitted on behalf of a third-party: [Realtime Robotics](https://rtr.ai)

### Description

WinRM (at least on tiny11) seems to have an internal 70-second timeout when it hasn't started yet that limits the rate at which WinRM connections are retried. This adds a timeout so that it can fail and retry early, to more quickly respond to when WinRM _does_ become available.

Untested, but does compile and seems trivial enough.

### Resolved Issues

*N.A.*

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Rollback Plan

*N.A.*

### Changes to Security Controls

*N.A.*
