### PR TITLE
Fix goroutine leaks for windows communicators

### DIFF
--- a/packer/communicator.go
+++ b/packer/communicator.go
@@ -126,12 +126,18 @@ func (r *RemoteCmd) RunWithUi(ctx context.Context, c Communicator, ui Ui) error 
 	// Create the channels we'll use for data
 	stdoutCh := iochan.DelimReader(stdout_r, '\n')
 	stderrCh := iochan.DelimReader(stderr_r, '\n')
+	cleanupCh := make(chan struct{})
+	defer close(cleanupCh)
 
 	// Start the goroutine to watch for the exit
 	go func() {
-		defer stdout_w.Close()
-		defer stderr_w.Close()
-		r.Wait()
+		select {
+		case <-r.exitCh:
+		case <-cleanupCh:
+		}
+
+		stdout_w.Close()
+		stderr_w.Close()
 	}()
 
 	// Loop and get all our output
@@ -141,32 +147,31 @@ func (r *RemoteCmd) RunWithUi(ctx context.Context, c Communicator, ui Ui) error 
 
 	go func() {
 		defer wg.Done()
-		exiting := false
 
-		for !exiting {
+		for stdoutCh != nil || stderrCh != nil {
 			select {
 			case output, ok := <-stderrCh:
-				if ok && output != "" {
+				if !ok {
+					stderrCh = nil
+					continue
+				}
+
+				if output != "" {
 					ui.Error(r.cleanOutputLine(output))
 				}
 			case output, ok := <-stdoutCh:
-				if ok && output != "" {
+				if !ok {
+					stdoutCh = nil
+					continue
+				}
+
+				if output != "" {
 					ui.Say(r.cleanOutputLine(output))
 				}
-			case <-r.exitCh:
-				exiting = true
 			case <-ctx.Done():
 				ctxErr = ctx.Err()
 				return
 			}
-		}
-
-		// Drain remaining messages from stdout and stderr if channels are still open.
-		for output := range stdoutCh {
-			ui.Say(r.cleanOutputLine(output))
-		}
-		for output := range stderrCh {
-			ui.Error(r.cleanOutputLine(output))
 		}
 	}()
 

--- a/packer/communicator_test.go
+++ b/packer/communicator_test.go
@@ -6,7 +6,10 @@ package packer
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
+	"os"
+	"runtime/pprof"
 	"strings"
 	"testing"
 	"time"
@@ -88,4 +91,148 @@ func TestRemoteCmd_Wait(t *testing.T) {
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("never got exit notification")
 	}
+}
+
+func TestRemoteCmd_RunWithUi_StartErrorDoesNotLeakGoroutines(t *testing.T) {
+	t.Parallel()
+
+	errExpected := errors.New("boom")
+	rc := &RemoteCmd{Command: "test"}
+	ui := &BasicUi{
+		Reader: new(bytes.Buffer),
+		Writer: io.Discard,
+	}
+
+	err := rc.RunWithUi(context.Background(), errorCommunicator{err: errExpected}, ui)
+	if !errors.Is(err, errExpected) {
+		t.Fatalf("expected %v, got %v", errExpected, err)
+	}
+
+	assertNoGoroutineStack(t,
+		"github.com/hashicorp/packer-plugin-sdk/packer.(*RemoteCmd).RunWithUi.func",
+		"github.com/hashicorp/packer-plugin-sdk/packer.(*RemoteCmd).Wait",
+	)
+}
+
+func TestRemoteCmd_RunWithUi_ContextCancelDoesNotLeakGoroutines(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rc := &RemoteCmd{Command: "test"}
+	ui := &BasicUi{
+		Reader: new(bytes.Buffer),
+		Writer: io.Discard,
+	}
+	comm := startedCommunicator{started: make(chan struct{})}
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- rc.RunWithUi(ctx, comm, ui)
+	}()
+
+	select {
+	case <-comm.started:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Start was never called")
+	}
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected %v, got %v", context.Canceled, err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("RunWithUi did not return promptly after cancellation")
+	}
+
+	assertNoGoroutineStack(t,
+		"github.com/hashicorp/packer-plugin-sdk/packer.(*RemoteCmd).RunWithUi.func",
+		"github.com/hashicorp/packer-plugin-sdk/packer.(*RemoteCmd).Wait",
+	)
+}
+
+type errorCommunicator struct {
+	err error
+}
+
+func (c errorCommunicator) Start(context.Context, *RemoteCmd) error {
+	return c.err
+}
+
+func (errorCommunicator) Upload(string, io.Reader, *os.FileInfo) error {
+	panic("unexpected Upload call")
+}
+
+func (errorCommunicator) UploadDir(string, string, []string) error {
+	panic("unexpected UploadDir call")
+}
+
+func (errorCommunicator) Download(string, io.Writer) error {
+	panic("unexpected Download call")
+}
+
+func (errorCommunicator) DownloadDir(string, string, []string) error {
+	panic("unexpected DownloadDir call")
+}
+
+type startedCommunicator struct {
+	started chan struct{}
+}
+
+func (c startedCommunicator) Start(context.Context, *RemoteCmd) error {
+	close(c.started)
+	return nil
+}
+
+func (startedCommunicator) Upload(string, io.Reader, *os.FileInfo) error {
+	panic("unexpected Upload call")
+}
+
+func (startedCommunicator) UploadDir(string, string, []string) error {
+	panic("unexpected UploadDir call")
+}
+
+func (startedCommunicator) Download(string, io.Writer) error {
+	panic("unexpected Download call")
+}
+
+func (startedCommunicator) DownloadDir(string, string, []string) error {
+	panic("unexpected DownloadDir call")
+}
+
+func assertNoGoroutineStack(t *testing.T, needles ...string) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		var stacks bytes.Buffer
+		if err := pprof.Lookup("goroutine").WriteTo(&stacks, 2); err != nil {
+			t.Fatalf("failed to dump goroutines: %v", err)
+		}
+
+		allGone := true
+		for _, needle := range needles {
+			if strings.Contains(stacks.String(), needle) {
+				allGone = false
+				break
+			}
+		}
+
+		if allGone {
+			return
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	var stacks bytes.Buffer
+	if err := pprof.Lookup("goroutine").WriteTo(&stacks, 2); err != nil {
+		t.Fatalf("failed to dump goroutines: %v", err)
+	}
+
+	t.Fatalf("expected goroutines to exit, still found matching stacks:\n%s", stacks.String())
 }


### PR DESCRIPTION
## Summary

This fixes goroutine leaks in `RemoteCmd.RunWithUi` that were introduced when the command start order changed in PR #298.

In the failure path where `c.Start(...)` returns an error, `RunWithUi` could return while helper goroutines were still running:
- one goroutine could remain blocked waiting on `r.exitCh`
- the output reader goroutine could continue selecting on closed stdout/stderr channels

Because receives from closed channels are always ready, that second goroutine could spin hot and drive CPU usage up, especially when restart/reconnect logic retried repeatedly.

## Related issues

- Fixes https://github.com/hashicorp/packer-plugin-sdk/issues/335
- Related to https://github.com/hashicorp/packer/issues/13483
- Related to https://github.com/hashicorp/packer-plugin-qemu/issues/246

## Root cause

PR #298 moved `c.Start(ctx, r)` to after the output goroutines were launched.

That created a bad error path:
1. `RunWithUi` created stdout/stderr readers and helper goroutines
2. `c.Start(...)` returned an error before the command actually started
3. `RunWithUi` returned immediately
4. `SetExited(...)` was never called, so `r.exitCh` never closed
5. deferred pipe closure caused the output channels to close
6. the reader goroutine kept selecting on those closed channels and could busy-spin

This was especially visible around Windows restart flows, where command start failures are expected during reconnect windows and can happen repeatedly.

## What changed

### `packer/communicator.go`

- added an explicit cleanup signal so the goroutine waiting on command exit can also terminate when `RunWithUi` unwinds early
- changed the reader loop to treat closed stdout/stderr channels as terminal by setting them to `nil`
- kept waiting for the reader goroutine so teardown is complete before returning

### `packer/communicator_test.go`

Added regression coverage for both problematic teardown paths:
- `TestRemoteCmd_RunWithUi_StartErrorDoesNotLeakGoroutines`
- `TestRemoteCmd_RunWithUi_ContextCancelDoesNotLeakGoroutines`

These tests verify:
- a `Start` error does not leave `RunWithUi` or `Wait` goroutines behind
- cancellation after `Start` succeeds returns promptly with `context.Canceled`
- the reader goroutine exits cleanly in both cases

## Why this fixes the reported behavior

This restores the missing cleanup on the `Start` error path and hardens the output loop so closed channels cannot cause a hot select loop.

That prevents the repeated retry pattern from accumulating leaked goroutines and pegging CPU during restart/reconnect scenarios.

## Testing

Validated with:
- `go test ./packer -run 'TestRemoteCmd_' -count=1`

I also ran the new start-error regression against the old pre-fix code in a clean temporary checkout:
- before the fix: test failed and showed one goroutine blocked in `Wait` and one runnable in `RunWithUi`
- after the fix: test passed