### PR TITLE
fix(shell-local): avoid ETXTBSY for inline scripts

### DIFF
--- a/shell-local/communicator_test.go
+++ b/shell-local/communicator_test.go
@@ -6,6 +6,7 @@ package shell_local
 import (
 	"bytes"
 	"context"
+	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -45,5 +46,51 @@ func TestCommunicator(t *testing.T) {
 
 	if strings.TrimSpace(buf.String()) != "foo" {
 		t.Fatalf("bad: %s", buf.String())
+	}
+}
+
+func TestDefaultInlineExecuteCommandRunsScriptOpenForWriting(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows does not reject executing a file that is open for writing")
+	}
+
+	script, err := os.CreateTemp(t.TempDir(), "packer-shell")
+	if err != nil {
+		t.Fatalf("creating script: %s", err)
+	}
+	t.Cleanup(func() { script.Close() })
+
+	if _, err := script.WriteString("echo foo\n"); err != nil {
+		t.Fatalf("writing script: %s", err)
+	}
+	if err := script.Chmod(0700); err != nil {
+		t.Fatalf("making script executable: %s", err)
+	}
+
+	config := &Config{}
+	config.Inline = []string{"echo foo"}
+	if err := Validate(config); err != nil {
+		t.Fatalf("validating config: %s", err)
+	}
+	config.generatedData = make(map[string]interface{})
+
+	executeCommand, err := createInterpolatedCommands(config, script.Name(), "")
+	if err != nil {
+		t.Fatalf("interpolating command: %s", err)
+	}
+
+	communicator := &Communicator{ExecuteCommand: executeCommand}
+	var stdout bytes.Buffer
+	cmd := &packersdk.RemoteCmd{Stdout: &stdout}
+	if err := communicator.Start(context.Background(), cmd); err != nil {
+		t.Fatalf("starting command: %s", err)
+	}
+	cmd.Wait()
+
+	if cmd.ExitStatus() != 0 {
+		t.Fatalf("bad exit status: %d", cmd.ExitStatus())
+	}
+	if strings.TrimSpace(stdout.String()) != "foo" {
+		t.Fatalf("bad output: %s", stdout.String())
 	}
 }

--- a/shell-local/config.go
+++ b/shell-local/config.go
@@ -73,29 +73,12 @@ func Validate(config *Config) error {
 	var errs *packersdk.MultiError
 
 	if runtime.GOOS == "windows" {
-		if len(config.ExecuteCommand) == 0 {
-			config.ExecuteCommand = []string{
-				"cmd",
-				"/V",
-				"/C",
-				"{{.Vars}}",
-				"call",
-				"{{.Script}}",
-			}
-		}
 		if len(config.TempfileExtension) == 0 {
 			config.TempfileExtension = ".cmd"
 		}
 	} else {
 		if config.InlineShebang == "" {
 			config.InlineShebang = "/bin/sh -e"
-		}
-		if len(config.ExecuteCommand) == 0 {
-			config.ExecuteCommand = []string{
-				"/bin/sh",
-				"-c",
-				"{{.Vars}} {{.Script}}",
-			}
 		}
 	}
 
@@ -124,6 +107,32 @@ func Validate(config *Config) error {
 			errs = packersdk.MultiErrorAppend(errs, tooManyOptionsErr)
 		} else {
 			config.Scripts = []string{config.Script}
+		}
+	}
+
+	if len(config.ExecuteCommand) == 0 {
+		if runtime.GOOS == "windows" {
+			config.ExecuteCommand = []string{
+				"cmd",
+				"/V",
+				"/C",
+				"{{.Vars}}",
+				"call",
+				"{{.Script}}",
+			}
+		} else if len(config.Inline) > 0 {
+			config.ExecuteCommand = []string{
+				"/bin/sh",
+				"-c",
+				fmt.Sprintf("{{.Vars}} %s \"$0\"", config.InlineShebang),
+				"{{.Script}}",
+			}
+		} else {
+			config.ExecuteCommand = []string{
+				"/bin/sh",
+				"-c",
+				"{{.Vars}} {{.Script}}",
+			}
 		}
 	}
 

--- a/shell-local/config_test.go
+++ b/shell-local/config_test.go
@@ -4,6 +4,8 @@
 package shell_local
 
 import (
+	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,4 +18,67 @@ func TestConvertToLinuxPath(t *testing.T) {
 	assert.Equal(t, winBashPath, converted,
 		"Should have converted %s to %s -- not %s", winPath, winBashPath, converted)
 
+}
+
+func TestValidateDefaultExecuteCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix execute command behavior")
+	}
+
+	tests := []struct {
+		name           string
+		configure      func(*Config)
+		executeCommand []string
+	}{
+		{
+			name: "inline invokes its shebang interpreter",
+			configure: func(config *Config) {
+				config.Inline = []string{"echo foo"}
+			},
+			executeCommand: []string{"/bin/sh", "-c", `{{.Vars}} /bin/sh -e "$0"`, "{{.Script}}"},
+		},
+		{
+			name: "command invokes its shebang interpreter",
+			configure: func(config *Config) {
+				config.Command = "echo foo"
+			},
+			executeCommand: []string{"/bin/sh", "-c", `{{.Vars}} /bin/sh -e "$0"`, "{{.Script}}"},
+		},
+		{
+			name: "custom inline shebang is preserved",
+			configure: func(config *Config) {
+				config.Inline = []string{"echo foo"}
+				config.InlineShebang = "/bin/bash -eu"
+			},
+			executeCommand: []string{"/bin/sh", "-c", `{{.Vars}} /bin/bash -eu "$0"`, "{{.Script}}"},
+		},
+		{
+			name: "script retains direct execution",
+			configure: func(config *Config) {
+				config.Script = os.DevNull
+			},
+			executeCommand: []string{"/bin/sh", "-c", "{{.Vars}} {{.Script}}"},
+		},
+		{
+			name: "custom execute command is preserved",
+			configure: func(config *Config) {
+				config.Inline = []string{"echo foo"}
+				config.ExecuteCommand = []string{"custom", "{{.Script}}"}
+			},
+			executeCommand: []string{"custom", "{{.Script}}"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := &Config{}
+			test.configure(config)
+
+			if err := Validate(config); err != nil {
+				t.Fatalf("validating config: %s", err)
+			}
+
+			assert.Equal(t, test.executeCommand, config.ExecuteCommand)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Update the default Unix execution path for generated `shell-local` inline scripts to invoke the configured `inline_shebang` interpreter instead of executing the temporary script directly.

Linux can reject direct execution with `ETXTBSY` (`Text file busy`) when the script is briefly held open for writing by the filesystem or another process. Invoking the interpreter causes it to read the script instead, avoiding that executable-file restriction.

## Compatibility

- Preserves custom `execute_command` values.
- Preserves the configured `inline_shebang` and its arguments.
- Keeps the existing direct execution behavior for user-supplied `script` and `scripts`.
- Leaves Windows behavior unchanged.