### PR TITLE
refactor: remove redundant else branches

### DIFF
--- a/acctest/pluginacc.go
+++ b/acctest/pluginacc.go
@@ -116,9 +116,9 @@ func TestPlugin(t *testing.T, testCase *PluginTestCase) {
 					"acceptance test template can be found at %s",
 					err.Error(), filepath.Join(cwd, initLogfile),
 					filepath.Join(cwd, templatePath))
-			} else {
-				os.Remove(initLogfile)
 			}
+
+			os.Remove(initLogfile)
 		}
 	}
 
@@ -156,8 +156,8 @@ func TestPlugin(t *testing.T, testCase *PluginTestCase) {
 			"acceptance test template can be found at %s",
 			checkErr.Error(), filepath.Join(cwd, logfile),
 			filepath.Join(cwd, templatePath))
-	} else {
-		os.Remove(templatePath)
-		os.Remove(logfile)
 	}
+
+	os.Remove(templatePath)
+	os.Remove(logfile)
 }

--- a/acctest/provisioneracc/provisioners.go
+++ b/acctest/provisioneracc/provisioners.go
@@ -248,10 +248,10 @@ func TestProvisionersAgainstBuilders(testCase *ProvisionerTestCase, t *testing.T
 						"acceptance test template can be found at %s",
 						checkErr.Error(), filepath.Join(cwd, logfile),
 						filepath.Join(cwd, templatePath))
-				} else {
-					os.Remove(templatePath)
-					os.Remove(logfile)
 				}
+
+				os.Remove(templatePath)
+				os.Remove(logfile)
 			})
 		}
 	}

--- a/multistep/commonsteps/multistep_runner.go
+++ b/multistep/commonsteps/multistep_runner.go
@@ -44,9 +44,9 @@ func newRunner(steps []multistep.Step, config common.PackerConfig, ui packersdk.
 	if config.PackerDebug {
 		pauseFn := MultistepDebugFn(ui)
 		return &multistep.DebugRunner{Steps: steps, PauseFn: pauseFn}, pauseFn
-	} else {
-		return &multistep.BasicRunner{Steps: steps}, nil
 	}
+
+	return &multistep.BasicRunner{Steps: steps}, nil
 }
 
 // NewRunner returns a multistep.Runner that runs steps augmented with support

--- a/rpc/build_test.go
+++ b/rpc/build_test.go
@@ -48,9 +48,9 @@ func (b *testBuild) Run(ctx context.Context, ui packersdk.Ui) ([]packersdk.Artif
 
 	if b.errRunResult {
 		return nil, errors.New("foo")
-	} else {
-		return []packersdk.Artifact{testBuildArtifact}, nil
 	}
+
+	return []packersdk.Artifact{testBuildArtifact}, nil
 }
 
 func (b *testBuild) SetDebug(bool) {

--- a/sdk-internals/communicator/ssh/communicator.go
+++ b/sdk-internals/communicator/ssh/communicator.go
@@ -179,18 +179,18 @@ func (c *comm) Start(ctx context.Context, cmd *packersdk.RemoteCmd) (err error) 
 func (c *comm) Upload(path string, input io.Reader, fi *os.FileInfo) error {
 	if c.config.UseSftp {
 		return c.sftpUploadSession(path, input, fi)
-	} else {
-		return c.scpUploadSession(path, input, fi)
 	}
+
+	return c.scpUploadSession(path, input, fi)
 }
 
 func (c *comm) UploadDir(dst string, src string, excl []string) error {
 	log.Printf("[DEBUG] Upload dir '%s' to '%s'", src, dst)
 	if c.config.UseSftp {
 		return c.sftpUploadDirSession(dst, src, excl)
-	} else {
-		return c.scpUploadDirSession(dst, src, excl)
 	}
+
+	return c.scpUploadDirSession(dst, src, excl)
 }
 
 func (c *comm) DownloadDir(src string, dst string, excl []string) error {
@@ -288,9 +288,9 @@ func (c *comm) newSession() (session *ssh.Session, err error) {
 
 		if c.client == nil {
 			return nil, errors.New("client not available")
-		} else {
-			return c.client.NewSession()
 		}
+
+		return c.client.NewSession()
 	}
 
 	return session, nil
@@ -695,10 +695,10 @@ func (c *comm) scpUploadDirSession(dst string, src string, excl []string) error 
 				return err
 			}
 			return scpUploadDirProtocol(srcBase, w, r, uploadEntries, fi)
-		} else {
-			// Trailing slash, so only upload the contents
-			return uploadEntries()
 		}
+
+		// Trailing slash, so only upload the contents
+		return uploadEntries()
 	}
 
 	return c.scpSession("scp -rvt "+dst, scpFunc)

--- a/template/config/custom_types.go
+++ b/template/config/custom_types.go
@@ -53,9 +53,9 @@ func TrileanFromString(s string) (Trilean, error) {
 		return TriUnset, err
 	} else if b {
 		return TriTrue, nil
-	} else {
-		return TriFalse, nil
 	}
+
+	return TriFalse, nil
 }
 
 func TrileanFromBool(b bool) Trilean {

--- a/template/interpolate/funcs.go
+++ b/template/interpolate/funcs.go
@@ -174,9 +174,9 @@ func passthroughOrInterpolate(data map[interface{}]interface{}, s string) (strin
 			// TODO match against an actual string constant
 			if strings.Contains(hp, packerbuilderdata.PlaceholderMsg) {
 				return fmt.Sprintf("{{.%s}}", s), nil
-			} else {
-				return hp, nil
 			}
+
+			return hp, nil
 		}
 	}
 	return "", fmt.Errorf("loaded data, but couldnt find %s in it.", s)


### PR DESCRIPTION
### Description

Removes unnecessary `else` clauses after terminating statements.

### Resolved Issues

Redundant `else` clauses in `if` statements that contain a `return`.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.
