### PR TITLE
refactor: use integer ranges for counted loops

### DIFF
--- a/multistep/commonsteps/step_create_floppy_test.go
+++ b/multistep/commonsteps/step_create_floppy_test.go
@@ -53,7 +53,7 @@ func TestStepCreateFloppy(t *testing.T) {
 	prefix := "exists"
 	ext := ".tmp"
 
-	for i := 0; i < expected; i++ {
+	for i := range expected {
 		files[i] = path.Join(dir, prefix+strconv.Itoa(i)+ext)
 
 		_, err := os.Create(files[i])
@@ -115,7 +115,7 @@ func TestStepCreateFloppy_missing(t *testing.T) {
 
 	prefix := "missing"
 
-	for i := 0; i < count; i++ {
+	for i := range count {
 		files[i] = path.Join(dir, prefix+strconv.Itoa(i))
 	}
 
@@ -160,7 +160,7 @@ func TestStepCreateFloppy_notfound(t *testing.T) {
 
 	prefix := "notfound"
 
-	for i := 0; i < count; i++ {
+	for i := range count {
 		files[i] = path.Join(dir, prefix+strconv.Itoa(i))
 	}
 
@@ -233,7 +233,7 @@ func TestStepCreateFloppyDirectories(t *testing.T) {
 	}
 
 	// create the hierarchy for each file
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		dir := filepath.Join(basePath, fmt.Sprintf("test-%d", i))
 
 		for _, test := range directories[i] {

--- a/multistep/commonsteps/step_output_dir.go
+++ b/multistep/commonsteps/step_output_dir.go
@@ -76,7 +76,7 @@ func (s *StepOutputDir) Cleanup(state multistep.StateBag) {
 		ui := state.Get("ui").(packersdk.Ui)
 
 		ui.Say("Deleting output directory...")
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			err := os.RemoveAll(s.Path)
 			if err == nil {
 				break

--- a/template/parse.go
+++ b/template/parse.go
@@ -551,7 +551,7 @@ func highlightPosition(f *os.File, pos int64) (line, col int, highlight string) 
 	lastLine := ""
 	thisLine := new(bytes.Buffer)
 	// Loop through template to find line, column
-	for n := int64(0); n < pos; n++ {
+	for range pos {
 		// read byte from io.Reader
 		b, err := br.ReadByte()
 		if err != nil {


### PR DESCRIPTION
### Description

Adopt Go 1.22+ integer range syntax to make loop intent clearer and eliminate manual initialization, conditions, and increments.

### Resolved Issues

In Go 1.22+, three-clause for loops of the form for `i := 0; i < n; I++` that can be replaced with for `i := range n ()`. Using range over an integer keeps the intent clear and removes boilerplate loop control code.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.