### PR TITLE
refactor: use maps.Copy for map merging

### DIFF
--- a/communicator/step_connect.go
+++ b/communicator/step_connect.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
 	"time"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
@@ -77,9 +78,7 @@ func (s *StepConnect) Run(ctx context.Context, state multistep.StateBag) multist
 			WinRMPort:   s.WinRMPort,
 		},
 	}
-	for k, v := range s.CustomConnect {
-		typeMap[k] = v
-	}
+	maps.Copy(typeMap, s.CustomConnect)
 
 	step, ok := typeMap[s.Config.Type]
 	if !ok {

--- a/template/interpolate/funcs.go
+++ b/template/interpolate/funcs.go
@@ -6,6 +6,7 @@ package interpolate
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -75,9 +76,7 @@ func Funcs(ctx *Context) template.FuncMap {
 		}
 	}
 	if ctx != nil {
-		for k, v := range ctx.Funcs {
-			result[k] = v
-		}
+		maps.Copy(result, ctx.Funcs)
 	}
 
 	return template.FuncMap(result)

--- a/template/parse.go
+++ b/template/parse.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -105,9 +106,7 @@ func (r *rawTemplate) Template() (*Template, error) {
 		result.Comments = make(map[string]string, len(r.Comments))
 
 		for _, c := range r.Comments {
-			for k, v := range c {
-				result.Comments[k] = v
-			}
+			maps.Copy(result.Comments, c)
 		}
 	}
 


### PR DESCRIPTION
### Description

Replaced manual map-copy loops with the standard library helper to express intent directly and reduce boilerplate.

### Resolved Issues

Loops that copy a map or collect its keys or values and can be replaced with `maps.Copy`, `maps.Keys`, or `maps.Values`. These helpers express the intent directly and reduce boilerplate code.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.
