### PR TITLE
refactor: use WaitGroup.Go for communicator tasks

### DIFF
--- a/packer/communicator.go
+++ b/packer/communicator.go
@@ -143,10 +143,8 @@ func (r *RemoteCmd) RunWithUi(ctx context.Context, c Communicator, ui Ui) error 
 	// Loop and get all our output
 	var wg sync.WaitGroup
 	var ctxErr error
-	wg.Add(1)
 
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 
 		for stdoutCh != nil || stderrCh != nil {
 			select {
@@ -173,7 +171,7 @@ func (r *RemoteCmd) RunWithUi(ctx context.Context, c Communicator, ui Ui) error 
 				return
 			}
 		}
-	}()
+	})
 
 	// Start the command
 	if err := c.Start(ctx, r); err != nil {

--- a/packer/communicator_mock.go
+++ b/packer/communicator_mock.go
@@ -47,29 +47,23 @@ func (c *MockCommunicator) Start(ctx context.Context, rc *RemoteCmd) error {
 	go func() {
 		var wg sync.WaitGroup
 		if rc.Stdout != nil && c.StartStdout != "" {
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				io.Copy(rc.Stdout, strings.NewReader(c.StartStdout))
-				wg.Done()
-			}()
+			})
 		}
 
 		if rc.Stderr != nil && c.StartStderr != "" {
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				io.Copy(rc.Stderr, strings.NewReader(c.StartStderr))
-				wg.Done()
-			}()
+			})
 		}
 
 		if rc.Stdin != nil {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				var data bytes.Buffer
 				io.Copy(&data, rc.Stdin)
 				c.StartStdin = data.String()
-			}()
+			})
 		}
 
 		wg.Wait()


### PR DESCRIPTION
### Description

Adopts the Go 1.25+ helper to keep goroutine launches and `WaitGroup` accounting together.

### Resolved Issues

Reduces boilerplate and prevents Add/Done mismatches.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.