### PR TITLE
refactor: use testing context for port configuration

### DIFF
--- a/net/configure_port_test.go
+++ b/net/configure_port_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestListenRangeConfig_Listen(t *testing.T) {
-	topCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	topCtx := t.Context()
 
 	var err error
 	var lockedListener *Listener


### PR DESCRIPTION
### Description

Replaced manual context cancellation with `t.Context` because it is cancelled automatically when the test ends.

### Resolved Issues

Keep the context lifecycle tied to the test and remove redundant cleanup.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.
