### PR TITLE
interpolate: replace placeholder "test" error in funcGenUser

### DIFF
--- a/template/interpolate/funcs.go
+++ b/template/interpolate/funcs.go
@@ -222,7 +222,7 @@ func funcGenTimestamp(ctx *Context) interface{} {
 func funcGenUser(ctx *Context) interface{} {
 	return func(k string) (string, error) {
 		if ctx == nil || ctx.UserVariables == nil {
-			return "", errors.New("test")
+			return "", errors.New("no user variables are set in the interpolation context")
 		}
 
 		val, ok := ctx.UserVariables[k]

--- a/template/interpolate/funcs_test.go
+++ b/template/interpolate/funcs_test.go
@@ -321,6 +321,19 @@ func TestFuncUser(t *testing.T) {
 	}
 }
 
+func TestFuncUser_nilUserVariables(t *testing.T) {
+	i := &I{Value: `{{user "foo"}}`}
+	_, err := i.Render(&Context{})
+	if err == nil {
+		t.Fatal("expected an error when UserVariables is nil")
+	}
+
+	expected := "no user variables are set in the interpolation context"
+	if !strings.Contains(err.Error(), expected) {
+		t.Fatalf("err: %s\n\nexpected it to contain: %s", err, expected)
+	}
+}
+
 func TestFuncPackerBuild(t *testing.T) {
 	type cases struct {
 		DataMap     interface{}


### PR DESCRIPTION
### Description

The `user` interpolation function returns the error `test` if the
interpolation context has no user variables
(`template/interpolate/funcs.go`, `funcGenUser`). The full message that
users see is:

```
error calling user: test
```

This text gives no information about the cause, and it looks like debug
code. Users reported confusion about this message more than one time:

- hashicorp/packer-plugin-vagrant#9 (from hashicorp/packer#10828): the
  reporter read the SDK source code to understand the message.
- hashicorp/packer-plugin-amazon#148: the reporter wrote that the message
  suggests "left-over debugging code".

This condition occurs if the Packer core does not send the
`packer_user_variables` config key to the plugin. Before
hashicorp/packer#13686, this was the normal condition for all HCL2 builds.

This PR replaces the text with a message that identifies the condition:

```
error calling user: no user variables are set in the interpolation context
```

The PR also adds a test for the nil-UserVariables condition. No test
referred to the old text, thus no other test changes are necessary.

### Resolved Issues

None in this repository. Related: hashicorp/packer#13686,
hashicorp/packer-plugin-vagrant#9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
