### PR TITLE
refactor: drop ineffective omitempty

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -104,7 +104,7 @@ func (b *Builder) MarshalJSON() ([]byte, error) {
 
 // PostProcessor represents a post-processor within the template.
 type PostProcessor struct {
-	OnlyExcept `mapstructure:",squash" json:",omitempty"`
+	OnlyExcept `mapstructure:",squash"`
 
 	Name              string                 `json:"name,omitempty"`
 	Type              string                 `json:"type"`
@@ -139,7 +139,7 @@ func (p *PostProcessor) MarshalJSON() ([]byte, error) {
 
 // Provisioner represents a provisioner within the template.
 type Provisioner struct {
-	OnlyExcept `mapstructure:",squash" json:",omitempty"`
+	OnlyExcept `mapstructure:",squash"`
 
 	Type        string                 `json:"type"`
 	Config      map[string]interface{} `json:"config,omitempty"`


### PR DESCRIPTION
### Description

`encoding/json` treats struct values as never empty, so `json:",omitempty"` on the embedded `OnlyExcept` field in `PostProcessor` and `Provisioner` has no effect.

Removes the misleading tags; `OnlyExcept `already applies `omitempty` to its `Only` and `Except` slice fields, and JSON output is unchanged.

### Resolved Issues

`encoding/json` treats struct values as never empty, so `json:",omitempty"` on the embedded `OnlyExcept` field in `PostProcessor` and `Provisioner` has no effect.

### Rollback Plan

Revery commit.

### Changes to Security Controls

None.