### PR TITLE
refactor: prefer `reflect.Pointer` over deprecated `Ptr` alias

### DIFF
--- a/retry/utils_test.go
+++ b/retry/utils_test.go
@@ -26,7 +26,7 @@ func structTypes(v reflect.Value, m map[reflect.Type]struct{}) {
 		return
 	}
 	switch v.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if !v.IsNil() {
 			structTypes(v.Elem(), m)
 		}


### PR DESCRIPTION
### Description

`reflect.Ptr` is marked `//go:fix inline` to `Pointer`.

Use the canonical Kind name in the test helper switch.

### Resolved Issues

`reflect.Ptr` is marked `//go:fix inline` to `Pointer`.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.
