### PR TITLE
refactor: normalize comments and identifiers

### DIFF
--- a/bootcommand/boot_command_ast.go
+++ b/bootcommand/boot_command_ast.go
@@ -96,7 +96,7 @@ type waitExpression struct {
 	d time.Duration
 }
 
-// Do waits the amount of time described by the expression. It is cancellable
+// Do waits the amount of time described by the expression. It is cancelable
 // through the context.
 func (w *waitExpression) Do(ctx context.Context, driver BCDriver) error {
 	driver.Flush()

--- a/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/SSHInterface-not-required.mdx
+++ b/cmd/packer-sdc/internal/renderdocs/docs-partials/packer-plugin-sdk/communicator/SSHInterface-not-required.mdx
@@ -2,7 +2,7 @@
 
 - `ssh_interface` (string) - One of `public_ip`, `private_ip`, `public_dns`, or `private_dns`. If
   set, either the public IP address, private IP address, public DNS name
-  or private DNS name will used as the host for SSH. The default behaviour
+  or private DNS name will used as the host for SSH. The default behavior
   if inside a VPC is to use the public IP address if available, otherwise
   the private IP address will be used. If not in a VPC the public DNS name
   will be used. Also works for WinRM.

--- a/communicator/config.go
+++ b/communicator/config.go
@@ -300,7 +300,7 @@ var (
 type SSHInterface struct {
 	// One of `public_ip`, `private_ip`, `public_dns`, or `private_dns`. If
 	// set, either the public IP address, private IP address, public DNS name
-	// or private DNS name will used as the host for SSH. The default behaviour
+	// or private DNS name will used as the host for SSH. The default behavior
 	// if inside a VPC is to use the public IP address if available, otherwise
 	// the private IP address will be used. If not in a VPC the public DNS name
 	// will be used. Also works for WinRM.

--- a/communicator/step_connect.go
+++ b/communicator/step_connect.go
@@ -50,7 +50,7 @@ type StepConnect struct {
 }
 
 func (s *StepConnect) pause(pauseLen time.Duration, ctx context.Context) bool {
-	// Use a select to determine if we get cancelled during the wait
+	// Use a select to determine if we get canceled during the wait
 	select {
 	case <-ctx.Done():
 		return true
@@ -122,8 +122,8 @@ func (s *StepConnect) Run(ctx context.Context, state multistep.StateBag) multist
 	if s.Config.PauseBeforeConnect > 0 {
 		ui.Say(fmt.Sprintf("Pausing %s before connecting...",
 			s.Config.PauseBeforeConnect.String()))
-		cancelled := s.pause(s.Config.PauseBeforeConnect, ctx)
-		if cancelled {
+		canceled := s.pause(s.Config.PauseBeforeConnect, ctx)
+		if canceled {
 			return multistep.ActionHalt
 		}
 		// After pause is complete, re-run the connect substep to make sure

--- a/communicator/step_connect_ssh.go
+++ b/communicator/step_connect_ssh.go
@@ -78,7 +78,7 @@ func (s *StepConnectSSH) Run(ctx context.Context, state multistep.StateBag) mult
 			cancel()
 			return multistep.ActionHalt
 		case <-ctx.Done():
-			// The step sequence was cancelled, so cancel waiting for SSH
+			// The step sequence was canceled, so cancel waiting for SSH
 			// and just start the halting process.
 			cancel()
 			log.Println("[WARN] Interrupt detected, quitting waiting for SSH.")
@@ -130,8 +130,8 @@ func (s *StepConnectSSH) waitForSSH(state multistep.StateBag, ctx context.Contex
 		if !first {
 			select {
 			case <-ctx.Done():
-				log.Println("[DEBUG] SSH wait cancelled. Exiting loop.")
-				return nil, errors.New("SSH wait cancelled")
+				log.Println("[DEBUG] SSH wait canceled. Exiting loop.")
+				return nil, errors.New("SSH wait canceled")
 			case <-time.After(5 * time.Second):
 			}
 		}

--- a/communicator/step_connect_winrm.go
+++ b/communicator/step_connect_winrm.go
@@ -80,7 +80,7 @@ func (s *StepConnectWinRM) Run(ctx context.Context, state multistep.StateBag) mu
 			cancel()
 			return multistep.ActionHalt
 		case <-ctx.Done():
-			// The step sequence was cancelled, so cancel waiting for WinRM
+			// The step sequence was canceled, so cancel waiting for WinRM
 			// and just start the halting process.
 			cancel()
 			log.Println("Interrupt detected, quitting waiting for WinRM.")
@@ -101,8 +101,8 @@ func (s *StepConnectWinRM) waitForWinRM(state multistep.StateBag, ctx context.Co
 		if !first {
 			select {
 			case <-ctx.Done():
-				log.Println("[INFO] WinRM wait cancelled. Exiting loop.")
-				return nil, errors.New("WinRM wait cancelled")
+				log.Println("[INFO] WinRM wait canceled. Exiting loop.")
+				return nil, errors.New("WinRM wait canceled")
 			case <-time.After(s.Config.WinRMRetryInterval):
 			}
 		}

--- a/hcl2helper/values.go
+++ b/hcl2helper/values.go
@@ -81,12 +81,12 @@ func HCL2ValueFromConfig(conf interface{}, configSpec map[string]hcldec.Spec) ct
 		// as I was working on other parts of the code at the same time.
 		//
 		// In the end, this may happen when the generated flat configs and
-		// the structures returned by the plugin are not synchronised, which
+		// the structures returned by the plugin are not synchronized, which
 		// causes the object spec to be out-of-sync with the data expected.
 		//
 		// Rather than letting the hcl library panic on a nil pointer problem,
 		// we do it here, with suggestions for users on how to potentially
-		// fix the problem, without needing to delve into the behaviour of
+		// fix the problem, without needing to delve into the behavior of
 		// the SDK and the HCL libraries.
 		if spec == nil {
 			panic(`The converted value failed to have its spec inferred from it, and will panic later down the process.

--- a/multistep/basic_runner.go
+++ b/multistep/basic_runner.go
@@ -14,7 +14,7 @@ type runState int32
 const (
 	stateIdle runState = iota
 	stateRunning
-	stateCancelling
+	stateCanceling
 )
 
 // BasicRunner is a Runner that just runs the given slice of steps.
@@ -65,7 +65,7 @@ func (b *BasicRunner) Run(ctx context.Context, state StateBag) {
 		}
 		// We also check for cancellation here since we can't be sure
 		// the goroutine that is running to set it actually ran.
-		if runState(atomic.LoadInt32((*int32)(&b.state))) == stateCancelling {
+		if runState(atomic.LoadInt32((*int32)(&b.state))) == stateCanceling {
 			state.Put(StateCancelled, true)
 			break
 		}

--- a/multistep/basic_runner_test.go
+++ b/multistep/basic_runner_test.go
@@ -38,9 +38,9 @@ func TestBasicRunner_Run(t *testing.T) {
 		t.Errorf("unexpected result: %#v", results)
 	}
 
-	// Test no halted or cancelled
+	// Test no halted or canceled
 	if _, ok := data.GetOk(StateCancelled); ok {
-		t.Errorf("cancelled should not be in state bag")
+		t.Errorf("canceled should not be in state bag")
 	}
 
 	if _, ok := data.GetOk(StateHalted); ok {
@@ -103,10 +103,10 @@ func TestBasicRunner_Cancel(t *testing.T) {
 
 	topCtx, topCtxCancel := context.WithCancel(context.Background())
 
-	checkCancelled := func(data StateBag) {
-		cancelled := data.Get(StateCancelled).(bool)
-		if !cancelled {
-			t.Fatal("state should be cancelled")
+	checkCanceled := func(data StateBag) {
+		canceled := data.Get(StateCancelled).(bool)
+		if !canceled {
+			t.Fatal("state should be canceled")
 		}
 	}
 
@@ -119,7 +119,7 @@ func TestBasicRunner_Cancel(t *testing.T) {
 			run: func(ctx context.Context, sb StateBag) StepAction {
 				return ActionContinue
 			},
-			cleanup: checkCancelled,
+			cleanup: checkCanceled,
 		},
 		TestStepFn{
 			run: func(ctx context.Context, sb StateBag) StepAction {
@@ -127,7 +127,7 @@ func TestBasicRunner_Cancel(t *testing.T) {
 				<-ctx.Done()
 				return ActionContinue
 			},
-			cleanup: checkCancelled,
+			cleanup: checkCanceled,
 		},
 		TestStepFn{
 			run: func(context.Context, StateBag) StepAction {
@@ -156,8 +156,8 @@ func TestBasicRunner_Cancel(t *testing.T) {
 		t.Errorf("unexpected result: %#v", results)
 	}
 
-	// Test that it says it is cancelled
-	checkCancelled(data)
+	// Test that it says it is canceled
+	checkCanceled(data)
 
 }
 
@@ -170,8 +170,8 @@ func TestBasicRunner_Cancel_Special(t *testing.T) {
 	state.Put("runner", r)
 	r.Run(context.Background(), state)
 
-	// test that state contains cancelled
+	// test that state contains canceled
 	if _, ok := state.GetOk(StateCancelled); !ok {
-		t.Errorf("cancelled should be in state bag")
+		t.Errorf("canceled should be in state bag")
 	}
 }

--- a/multistep/commonsteps/step_download.go
+++ b/multistep/commonsteps/step_download.go
@@ -134,7 +134,7 @@ func (s *StepDownload) Run(ctx context.Context, state multistep.StateBag) multis
 
 	for _, source := range s.Url {
 		if ctx.Err() != nil {
-			state.Put("error", fmt.Errorf("Download cancelled: %v", errs))
+			state.Put("error", fmt.Errorf("Download canceled: %v", errs))
 			return multistep.ActionHalt
 		}
 		ui.Say(fmt.Sprintf("Trying %s", source))

--- a/multistep/commonsteps/step_output_dir.go
+++ b/multistep/commonsteps/step_output_dir.go
@@ -69,10 +69,10 @@ func (s *StepOutputDir) Cleanup(state multistep.StateBag) {
 		return
 	}
 
-	_, cancelled := state.GetOk(multistep.StateCancelled)
+	_, canceled := state.GetOk(multistep.StateCancelled)
 	_, halted := state.GetOk(multistep.StateHalted)
 
-	if cancelled || halted {
+	if canceled || halted {
 		ui := state.Get("ui").(packersdk.Ui)
 
 		ui.Say("Deleting output directory...")

--- a/multistep/commonsteps/step_output_dir_test.go
+++ b/multistep/commonsteps/step_output_dir_test.go
@@ -87,7 +87,7 @@ func TestStepOutputDir_exists(t *testing.T) {
 	}
 }
 
-func TestStepOutputDir_cancelled(t *testing.T) {
+func TestStepOutputDir_canceled(t *testing.T) {
 	state := testState(t)
 	step := testStepOutputDir(t)
 

--- a/multistep/commonsteps/step_provision.go
+++ b/multistep/commonsteps/step_provision.go
@@ -150,11 +150,11 @@ func (s *StepProvision) runWithHook(ctx context.Context, state multistep.StateBa
 
 			return multistep.ActionContinue
 		case <-ctx.Done():
-			log.Printf("Cancelling provisioning due to context cancellation: %s", ctx.Err())
+			log.Printf("Canceling provisioning due to context cancellation: %s", ctx.Err())
 			return multistep.ActionHalt
 		case <-time.After(1 * time.Second):
 			if _, ok := state.GetOk(multistep.StateCancelled); ok {
-				log.Println("Cancelling provisioning due to interrupt...")
+				log.Println("Canceling provisioning due to interrupt...")
 				return multistep.ActionHalt
 			}
 		}

--- a/multistep/debug_runner_test.go
+++ b/multistep/debug_runner_test.go
@@ -100,10 +100,10 @@ func TestDebugRunner_Cancel(t *testing.T) {
 
 	topCtx, topCtxCancel := context.WithCancel(context.Background())
 
-	checkCancelled := func(data StateBag) {
-		cancelled := data.Get(StateCancelled).(bool)
-		if !cancelled {
-			t.Fatal("state should be cancelled")
+	checkCanceled := func(data StateBag) {
+		canceled := data.Get(StateCancelled).(bool)
+		if !canceled {
+			t.Fatal("state should be canceled")
 		}
 	}
 
@@ -116,7 +116,7 @@ func TestDebugRunner_Cancel(t *testing.T) {
 			run: func(ctx context.Context, sb StateBag) StepAction {
 				return ActionContinue
 			},
-			cleanup: checkCancelled,
+			cleanup: checkCanceled,
 		},
 		TestStepFn{
 			run: func(ctx context.Context, sb StateBag) StepAction {
@@ -124,7 +124,7 @@ func TestDebugRunner_Cancel(t *testing.T) {
 				<-ctx.Done()
 				return ActionContinue
 			},
-			cleanup: checkCancelled,
+			cleanup: checkCanceled,
 		},
 		TestStepFn{
 			run: func(context.Context, StateBag) StepAction {
@@ -153,13 +153,13 @@ func TestDebugRunner_Cancel(t *testing.T) {
 		t.Errorf("unexpected result: %#v", results)
 	}
 
-	// Test that it says it is cancelled
-	cancelled, ok := data.GetOk(StateCancelled)
+	// Test that it says it is canceled
+	canceled, ok := data.GetOk(StateCancelled)
 	if !ok {
-		t.Fatal("could not get state cancelled")
+		t.Fatal("could not get state canceled")
 	}
-	if !cancelled.(bool) {
-		t.Errorf("not cancelled")
+	if !canceled.(bool) {
+		t.Errorf("not canceled")
 	}
 }
 

--- a/multistep/doc.go
+++ b/multistep/doc.go
@@ -4,7 +4,7 @@
 /*
 multistep is a Go library for building up complex actions using discrete,
 individual "steps." These steps are strung together and run in sequence
-to achieve a more complex goal. The runner handles cleanup, cancelling, etc.
+to achieve a more complex goal. The runner handles cleanup, canceling, etc.
 if necessary.
 
 # Basic Example
@@ -26,7 +26,7 @@ which is passed between steps by the runner.
 
 	func (s *stepAdd) Cleanup(multistep.StateBag) {
 		// This is called after all the steps have run or if the runner is
-		// cancelled so that cleanup can be performed.
+		// canceled so that cleanup can be performed.
 	}
 
 Make a runner and call your array of Steps.

--- a/multistep/multistep.go
+++ b/multistep/multistep.go
@@ -31,7 +31,7 @@ func (a StepAction) String() string {
 }
 
 // This is the key set in the state bag when using the basic runner to
-// signal that the step sequence was cancelled.
+// signal that the step sequence was canceled.
 const StateCancelled = "cancelled"
 
 // This is the key set in the state bag when a step halted the sequence.
@@ -41,7 +41,7 @@ const StateHalted = "halted"
 // of other steps, responsible for performing some specific action.
 type Step interface {
 	// Run is called to perform the action. The passed through context will be
-	// cancelled when the runner is cancelled. The second parameter is a "state
+	// canceled when the runner is canceled. The second parameter is a "state
 	// bag" of untyped things. Please be very careful about type-checking the
 	// items in this bag.
 	//

--- a/multistep/multistep_test.go
+++ b/multistep/multistep_test.go
@@ -25,7 +25,7 @@ type TestStepSync struct {
 type TestStepWaitForever struct {
 }
 
-// A step that manually flips state to cancelling in run
+// A step that manually flips state to canceling in run
 type TestStepInjectCancel struct {
 }
 
@@ -71,7 +71,7 @@ func (s TestStepWaitForever) Cleanup(StateBag) {}
 
 func (s TestStepInjectCancel) Run(ctx context.Context, state StateBag) StepAction {
 	r := state.Get("runner").(*BasicRunner)
-	r.state = stateCancelling
+	r.state = stateCanceling
 	return ActionContinue
 }
 

--- a/net/configure_port.go
+++ b/net/configure_port.go
@@ -67,7 +67,7 @@ type ListenRangeConfig struct {
 }
 
 // Listen tries to Listen to a random open TCP port in the [min, max) range
-// until ctx is cancelled.
+// until ctx is canceled.
 // Listen uses net.ListenConfig.Listen internally.
 func (lc ListenRangeConfig) Listen(ctx context.Context) (*Listener, error) {
 	if lc.Network == "" {

--- a/packer/build.go
+++ b/packer/build.go
@@ -20,7 +20,7 @@ type Build interface {
 
 	// Run runs the actual builder, returning an artifact implementation
 	// of what is built. If anything goes wrong, an error is returned.
-	// Run can be context cancelled.
+	// Run can be context canceled.
 	Run(context.Context, Ui) ([]Artifact, error)
 
 	// SetDebug will enable/disable debug mode. Debug mode is always

--- a/packer/communicator.go
+++ b/packer/communicator.go
@@ -90,7 +90,7 @@ type ConfigurableCommunicator interface {
 
 // RunWithUi runs the remote command and streams the output to any configured
 // Writers for stdout/stderr, while also writing each line as it comes to a Ui.
-// RunWithUi will not return until the command finishes or is cancelled.
+// RunWithUi will not return until the command finishes or is canceled.
 func (r *RemoteCmd) RunWithUi(ctx context.Context, c Communicator, ui Ui) error {
 	r.initchan()
 

--- a/packer/hook_test.go
+++ b/packer/hook_test.go
@@ -38,7 +38,7 @@ func TestDispatchHook_Run(t *testing.T) {
 }
 
 // A helper Hook implementation for testing cancels.
-// Run will wait indetinitelly until ctx is cancelled.
+// Run will wait indetinitelly until ctx is canceled.
 type CancelHook struct {
 	cancel func()
 }

--- a/packer/post_processor.go
+++ b/packer/post_processor.go
@@ -26,6 +26,6 @@ type PostProcessor interface {
 	// given a value to keep_input_artifact. If forceOverride is true, then any
 	// user input for keep_input_artifact is ignored and the artifact is either
 	// kept or discarded according to the value set in `keep`.
-	// PostProcess is cancellable using context
+	// PostProcess is cancelable using context
 	PostProcess(context.Context, Ui, Artifact) (a Artifact, keep bool, forceOverride bool, err error)
 }

--- a/pathing/config_file.go
+++ b/pathing/config_file.go
@@ -60,7 +60,7 @@ func homeDir() (string, error) {
 	u, err := user.Current()
 
 	// Get homedir from specified username
-	// if it is set and different than what we have
+	// if it is set and different from what we have
 	if username := os.Getenv("USER"); username != "" && err == nil && u.Username != username {
 		u, err = user.Lookup(username)
 	}

--- a/plugin/set.go
+++ b/plugin/set.go
@@ -42,7 +42,7 @@ type Set struct {
 
 // ProtocolVersion2 serves as a compatibility argument to the SetDescription
 // so plugins can report whether or not they support protobuf/msgpack for
-// serialising some of their entities (typically ObjectSpec) to protobuf.
+// serializing some of their entities (typically ObjectSpec) to protobuf.
 //
 // If absent from the SetDescription, it means only gob is supported, and both
 // Packer and the plugins should use that for communication.

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -43,7 +43,7 @@ func (err *RetryExhaustedError) Error() string {
 
 // Run will repeatedly retry the proivided fn within the constraints set in the
 // retry Config. It will retry until one of the following conditions is met:
-//   - The provided context is cancelled.
+//   - The provided context is canceled.
 //   - The Config.StartTimeout time has passed.
 //   - The function returns without an error.
 //   - The maximum number of tries, Config.Tries is exceeded.

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -34,7 +34,7 @@ func (ran *failOnce) Run(context.Context) error {
 }
 
 func TestConfig_Run(t *testing.T) {
-	cancelledCtx, cancel := context.WithCancel(context.Background())
+	canceledCtx, cancel := context.WithCancel(context.Background())
 	cancel()
 	type fields struct {
 		StartTimeout time.Duration
@@ -55,13 +55,13 @@ func TestConfig_Run(t *testing.T) {
 			fields{StartTimeout: time.Second},
 			args{context.Background(), success},
 			nil},
-		{"context cancelled",
+		{"context canceled",
 			fields{StartTimeout: time.Second},
-			args{cancelledCtx, wait},
+			args{canceledCtx, wait},
 			context.Canceled},
 		{"timeout",
 			fields{StartTimeout: 20 * time.Millisecond, RetryDelay: func() time.Duration { return 10 * time.Millisecond }},
-			args{cancelledCtx, fail},
+			args{canceledCtx, fail},
 			failErr},
 		{"success after one failure",
 			fields{Tries: 2, RetryDelay: func() time.Duration { return 0 }},

--- a/rpc/build.go
+++ b/rpc/build.go
@@ -60,9 +60,9 @@ func (b *build) Run(ctx context.Context, ui packersdk.Ui) ([]packersdk.Artifact,
 	go func() {
 		select {
 		case <-ctx.Done():
-			log.Printf("Cancelling build after context cancellation %v", ctx.Err())
+			log.Printf("Canceling build after context cancellation %v", ctx.Err())
 			if err := b.client.Call("Build.Cancel", new(interface{}), new(interface{})); err != nil {
-				log.Printf("Error cancelling builder: %s", err)
+				log.Printf("Error canceling builder: %s", err)
 			}
 		case <-done:
 		}

--- a/rpc/builder.go
+++ b/rpc/builder.go
@@ -66,9 +66,9 @@ func (b *builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	go func() {
 		select {
 		case <-ctx.Done():
-			log.Printf("Cancelling builder after context cancellation %v", ctx.Err())
+			log.Printf("Canceling builder after context cancellation %v", ctx.Err())
 			if err := b.client.Call(b.endpoint+".Cancel", new(interface{}), new(interface{})); err != nil {
-				log.Printf("Error cancelling builder: %s", err)
+				log.Printf("Error canceling builder: %s", err)
 			}
 		case <-done:
 		}

--- a/rpc/builder_test.go
+++ b/rpc/builder_test.go
@@ -134,11 +134,11 @@ func TestBuilderCancel(t *testing.T) {
 	// var runCtx context.Context
 
 	b := new(packersdk.MockBuilder)
-	cancelled := false
+	canceled := false
 	b.RunFn = func(ctx context.Context) {
 		topCtxCancel()
 		<-ctx.Done()
-		cancelled = true
+		canceled = true
 	}
 	client, server := testClientServer(t)
 	defer client.Close()
@@ -151,8 +151,8 @@ func TestBuilderCancel(t *testing.T) {
 		t.Fatalf("mock shouldnt retun run error for cancellation")
 	}
 
-	if !cancelled {
-		t.Fatal("context should have been cancelled")
+	if !canceled {
+		t.Fatal("context should have been canceled")
 	}
 }
 

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -22,7 +22,7 @@ type Client struct {
 	client   *rpc.Client
 	closeMux bool
 	// UseProto makes it so that clients started from this will use
-	// protobuf/msgpack for serialisation instead of gob
+	// protobuf/msgpack for serialization instead of gob
 	UseProto bool
 }
 

--- a/rpc/common.go
+++ b/rpc/common.go
@@ -26,7 +26,7 @@ type commonClient struct {
 	client   *rpc.Client
 	mux      *muxBroker
 
-	// useProto lets us determine whether or not we should use protobuf for serialising
+	// useProto lets us determine whether or not we should use protobuf for serializing
 	// data over RPC instead of gob.
 	//
 	// This is controlled by Packer using the `--use-proto` flag on plugin commands.
@@ -40,7 +40,7 @@ type commonServer struct {
 		ConfigSpec() hcldec.ObjectSpec
 	}
 
-	// useProto lets us determine whether or not we should use protobuf for serialising
+	// useProto lets us determine whether or not we should use protobuf for serializing
 	// data over RPC instead of gob.
 	//
 	// This is controlled by Packer using the `--use-proto` flag on plugin commands.
@@ -115,7 +115,7 @@ func (s *commonServer) ConfigSpec(_ interface{}, reply *ConfigSpecResponse) erro
 	return nil
 }
 
-// hcl2SpecToProtobuf converts a hcldec.ObjectSpec to a protobuf-serialised
+// hcl2SpecToProtobuf converts a hcldec.ObjectSpec to a protobuf-serialized
 // byte array so it can then be used to send to a Plugin/Packer.
 func hcl2SpecToProtobuf(spec hcldec.ObjectSpec) ([]byte, error) {
 	ret, err := ToProto(spec)
@@ -124,7 +124,7 @@ func hcl2SpecToProtobuf(spec hcldec.ObjectSpec) ([]byte, error) {
 	}
 	rawBytes, err := proto.Marshal(ret)
 	if err != nil {
-		return nil, fmt.Errorf("failed to serialise hclspec.Spec to protobuf: %s", err)
+		return nil, fmt.Errorf("failed to serialize hclspec.Spec to protobuf: %s", err)
 	}
 
 	return rawBytes, nil

--- a/rpc/convert.go
+++ b/rpc/convert.go
@@ -11,7 +11,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// ToProto converts a hcldec.Spec to a protobuf-serialisable equivalent.
+// ToProto converts a hcldec.Spec to a protobuf-serializable equivalent.
 //
 // This can then be used for gRPC communication over-the-wire for Packer plugins.
 func ToProto(spec hcldec.Spec) (*Spec, error) {

--- a/rpc/datasource.go
+++ b/rpc/datasource.go
@@ -60,7 +60,7 @@ func (d *datasource) OutputSpec() hcldec.ObjectSpec {
 		res := hcldec.ObjectSpec{}
 		err := gob.NewDecoder(bytes.NewReader(resp.OutputSpec)).Decode(&res)
 		if err != nil {
-			panic(fmt.Sprintf("datasource: failed to deserialise HCL spec from gob: %s", err))
+			panic(fmt.Sprintf("datasource: failed to deserialize HCL spec from gob: %s", err))
 		}
 		return res
 	}
@@ -68,7 +68,7 @@ func (d *datasource) OutputSpec() hcldec.ObjectSpec {
 	log.Printf("[DEBUG] - datasource: receiving OutputSpec as gob")
 	res, err := protobufToHCL2Spec(resp.OutputSpec)
 	if err != nil {
-		panic(fmt.Sprintf("datasource: failed to deserialise HCL spec from protobuf: %s", err))
+		panic(fmt.Sprintf("datasource: failed to deserialize HCL spec from protobuf: %s", err))
 	}
 	return res
 }

--- a/rpc/hook.go
+++ b/rpc/hook.go
@@ -46,9 +46,9 @@ func (h *hook) Run(ctx context.Context, name string, ui packersdk.Ui, comm packe
 	go func() {
 		select {
 		case <-ctx.Done():
-			log.Printf("Cancelling hook after context cancellation %v", ctx.Err())
+			log.Printf("Canceling hook after context cancellation %v", ctx.Err())
 			if err := h.client.Call(h.endpoint+".Cancel", new(interface{}), new(interface{})); err != nil {
-				log.Printf("Error cancelling builder: %s", err)
+				log.Printf("Error canceling builder: %s", err)
 			}
 		case <-done:
 		}

--- a/rpc/post_processor.go
+++ b/rpc/post_processor.go
@@ -59,9 +59,9 @@ func (p *postProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, a pack
 	go func() {
 		select {
 		case <-ctx.Done():
-			log.Printf("Cancelling post-processor after context cancellation %v", ctx.Err())
+			log.Printf("Canceling post-processor after context cancellation %v", ctx.Err())
 			if err := p.client.Call(p.endpoint+".Cancel", new(interface{}), new(interface{})); err != nil {
-				log.Printf("Error cancelling post-processor: %s", err)
+				log.Printf("Error canceling post-processor: %s", err)
 			}
 		case <-done:
 		}

--- a/rpc/provisioner.go
+++ b/rpc/provisioner.go
@@ -57,9 +57,9 @@ func (p *provisioner) Provision(ctx context.Context, ui packersdk.Ui, comm packe
 	go func() {
 		select {
 		case <-ctx.Done():
-			log.Printf("Cancelling provisioner after context cancellation %v", ctx.Err())
+			log.Printf("Canceling provisioner after context cancellation %v", ctx.Err())
 			if err := p.client.Call(p.endpoint+".Cancel", new(interface{}), new(interface{})); err != nil {
-				log.Printf("Error cancelling provisioner: %s", err)
+				log.Printf("Error canceling provisioner: %s", err)
 			}
 		case <-done:
 		}


### PR DESCRIPTION
### Description

Prefer American English spellings (_e.g._,`-ize`, single `-l-`, `-or`).

**Note**: `StateCancelled` stays because it's exported and the "cancelled" string is a public state-bag key. Renaming that would break consumers.

Ref: https://www.merriam-webster.com/grammar/canceled-or-cancelled

### Resolved Issues

Prefer American English spellings.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.
