### PR TITLE
refactor: add explicit defaults in reflect switch blocks

### DIFF
--- a/retry/utils_test.go
+++ b/retry/utils_test.go
@@ -47,5 +47,7 @@ func structTypes(v reflect.Value, m map[reflect.Type]struct{}) {
 		for i := 0; i < v.NumField(); i++ {
 			structTypes(v.Field(i), m)
 		}
+	default:
+		// Scalars and other kinds have no nested structs.
 	}
 }

--- a/template/interpolate/render.go
+++ b/template/interpolate/render.go
@@ -194,6 +194,8 @@ func (w *renderWalker) Exit(loc reflectwalk.Location) error {
 		w.cs = w.cs[:len(w.cs)-1]
 	case reflectwalk.SliceElem:
 		w.csKey = w.csKey[:len(w.csKey)-1]
+	default:
+		// This walker only stacks maps and slices.
 	}
 
 	return nil


### PR DESCRIPTION
### Description

Add no-op `default` branches with clarifying comments in two reflection-based switch statements (`structTypes` and `renderWalker.Exit`). The compiler does not require exhaustive switches, but unlisted `reflectwalk.Location` and `reflect.Kind `values were left implicit.

This documents intentional handling for non-container kinds and keeps the switch logic explicit without changing behavior.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None