### PR TITLE
refactor: use `errors.As/Is` for idiomatic error checks

### DIFF
--- a/cmd/packer-sdc/internal/fs/sync.go
+++ b/cmd/packer-sdc/internal/fs/sync.go
@@ -101,7 +101,8 @@ func syncFile(src, dst string) error {
 				//
 				// ERROR_PRIVILEGE_NOT_HELD is 1314 (0x522):
 				// https://msdn.microsoft.com/en-us/library/windows/desktop/ms681385(v=vs.85).aspx
-				if lerr, ok := err.(*os.LinkError); ok && lerr.Err != syscall.Errno(1314) {
+				var lerr *os.LinkError
+				if errors.As(err, &lerr) && !errors.Is(lerr.Err, syscall.Errno(1314)) {
 					return err
 				}
 			} else {

--- a/packer/multi_error.go
+++ b/packer/multi_error.go
@@ -4,6 +4,7 @@
 package packer
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -30,28 +31,10 @@ func (e *MultiError) Error() string {
 // onto a MultiError in order to create a larger multi-error. If the
 // original error is not a MultiError, it will be turned into one.
 func MultiErrorAppend(err error, errs ...error) *MultiError {
+	var me *MultiError
 	if err == nil {
-		err = new(MultiError)
-	}
-
-	switch err := err.(type) {
-	case *MultiError:
-		if err == nil {
-			err = new(MultiError)
-		}
-
-		for _, verr := range errs {
-			switch rhsErr := verr.(type) {
-			case *MultiError:
-				if rhsErr != nil {
-					err.Errors = append(err.Errors, rhsErr.Errors...)
-				}
-			default:
-				err.Errors = append(err.Errors, verr)
-			}
-		}
-		return err
-	default:
+		me = new(MultiError)
+	} else if !errors.As(err, &me) || me == nil {
 		newErrs := make([]error, len(errs)+1)
 		newErrs[0] = err
 		copy(newErrs[1:], errs)
@@ -59,4 +42,14 @@ func MultiErrorAppend(err error, errs ...error) *MultiError {
 			Errors: newErrs,
 		}
 	}
+
+	for _, verr := range errs {
+		var rhs *MultiError
+		if errors.As(verr, &rhs) && rhs != nil {
+			me.Errors = append(me.Errors, rhs.Errors...)
+		} else {
+			me.Errors = append(me.Errors, verr)
+		}
+	}
+	return me
 }

--- a/sdk-internals/communicator/ssh/communicator.go
+++ b/sdk-internals/communicator/ssh/communicator.go
@@ -160,11 +160,13 @@ func (c *comm) Start(ctx context.Context, cmd *packersdk.RemoteCmd) (err error) 
 		err := session.Wait()
 		exitStatus := 0
 		if err != nil {
-			switch err := err.(type) {
-			case *ssh.ExitError:
-				exitStatus = err.ExitStatus()
+			var exitErr *ssh.ExitError
+			var missingErr *ssh.ExitMissingError
+			switch {
+			case errors.As(err, &exitErr):
+				exitStatus = exitErr.ExitStatus()
 				log.Printf("[ERROR] Remote command exited with '%d': %s", exitStatus, cmd.Command)
-			case *ssh.ExitMissingError:
+			case errors.As(err, &missingErr):
 				log.Printf("[ERROR] Remote command exited without exit status or exit signal.")
 				exitStatus = packersdk.CmdDisconnect
 			default:
@@ -816,7 +818,8 @@ func (c *comm) scpSession(scpCommand string, f func(io.Writer, *bufio.Reader) er
 	err = session.Wait()
 	log.Printf("[DEBUG] scp stderr (length %d): %s", stderr.Len(), stderr.String())
 	if err != nil {
-		if exitErr, ok := err.(*ssh.ExitError); ok {
+		var exitErr *ssh.ExitError
+		if errors.As(err, &exitErr) {
 			// Otherwise, we have an ExitError, meaning we can just read the
 			// exit status
 			log.Printf("[DEBUG] non-zero exit status: %d, %v", exitErr.ExitStatus(), err)

--- a/sdk-internals/communicator/ssh/communicator_test.go
+++ b/sdk-internals/communicator/ssh/communicator_test.go
@@ -8,6 +8,7 @@ package ssh
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"testing"
@@ -220,7 +221,7 @@ func TestHandshakeTimeout(t *testing.T) {
 	}
 
 	_, err := New(address, config)
-	if err != ErrHandshakeTimeout {
+	if !errors.Is(err, ErrHandshakeTimeout) {
 		// Note: there's another error that can come back from this call:
 		//   ssh: handshake failed: EOF
 		// This should appear in cases where the handshake fails because of

--- a/template/config/decode.go
+++ b/template/config/decode.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"reflect"
@@ -68,9 +69,9 @@ func Decode(target interface{}, config *DecodeOpts, raws ...interface{}) error {
 		flatCfg := ctarget.FlatMapstructure()
 		err := gocty.FromCtyValue(cval, flatCfg)
 		if err != nil {
-			switch err := err.(type) {
-			case cty.PathError:
-				return fmt.Errorf("%v: %v", err, err.Path)
+			var pathErr cty.PathError
+			if errors.As(err, &pathErr) {
+				return fmt.Errorf("%v: %v", pathErr, pathErr.Path)
 			}
 			return err
 		}


### PR DESCRIPTION
### Description

Replace direct type assertions and equality checks with `errors.As` and `errors.Is` to properly handle wrapped errors.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None
