### PR TITLE
refactor: close files, connections, and rpc

### DIFF
--- a/acctest/provisioneracc/provisioners.go
+++ b/acctest/provisioneracc/provisioners.go
@@ -283,6 +283,7 @@ func writeJsonTemplate(out *bytes.Buffer, filePath string, t *testing.T) {
 	if err != nil {
 		t.Fatalf("bad: failed to create template file: %s", err.Error())
 	}
+	defer outputFile.Close()
 	_, err = outputFile.Write(out.Bytes())
 	if err != nil {
 		t.Fatalf("bad: failed to write template file: %s", err.Error())

--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -68,10 +68,11 @@ func (c *Adapter) Serve() {
 
 func (c *Adapter) Handle(conn net.Conn, ui packersdk.Ui) error {
 	log.Print("SSH proxy: accepted connection")
-	_, chans, reqs, err := ssh.NewServerConn(conn, c.config)
+	sshConn, chans, reqs, err := ssh.NewServerConn(conn, c.config)
 	if err != nil {
 		return errors.New("failed to handshake")
 	}
+	defer sshConn.Close()
 
 	// discard all global requests
 	go ssh.DiscardRequests(reqs)

--- a/chroot/communicator.go
+++ b/chroot/communicator.go
@@ -77,6 +77,7 @@ func (c *Communicator) Upload(dst string, r io.Reader, fi *os.FileInfo) error {
 		return fmt.Errorf("Error preparing shell script: %s", err)
 	}
 	defer os.Remove(tf.Name())
+	defer tf.Close()
 
 	if _, err := io.Copy(tf, r); err != nil {
 		return err

--- a/cmd/packer-sdc/internal/fs/sync.go
+++ b/cmd/packer-sdc/internal/fs/sync.go
@@ -122,6 +122,7 @@ func syncFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
+	defer out.Close()
 
 	inS, err := in.Stat()
 	if err != nil {

--- a/cmd/packer-sdc/internal/mapstructure-to-hcl2/mapstructure-to-hcl2.go
+++ b/cmd/packer-sdc/internal/mapstructure-to-hcl2/mapstructure-to-hcl2.go
@@ -230,6 +230,7 @@ func (cmd *Command) Run(args []string) int {
 	if err != nil {
 		log.Fatalf("os.Create: %v", err)
 	}
+	defer outputFile.Close()
 
 	_, err = outputFile.Write(goFmt(outputFile.Name(), out.Bytes()))
 	if err != nil {

--- a/multistep/commonsteps/step_create_floppy.go
+++ b/multistep/commonsteps/step_create_floppy.go
@@ -76,6 +76,7 @@ func (s *StepCreateFloppy) Run(ctx context.Context, state multistep.StateBag) mu
 		state.Put("error", fmt.Errorf("Error creating floppy: %s", err))
 		return multistep.ActionHalt
 	}
+	defer device.Close()
 
 	// Format the block device so it contains a valid FAT filesystem
 	log.Println("Formatting the block device with a FAT filesystem...")

--- a/plugin/set.go
+++ b/plugin/set.go
@@ -157,6 +157,7 @@ func (i *Set) start(kind, name string) error {
 	if err != nil {
 		return err
 	}
+	defer server.Close()
 	server.UseProto = i.useProto
 
 	log.Printf("[TRACE] starting %s %s", kind, name)

--- a/rpc/build.go
+++ b/rpc/build.go
@@ -53,7 +53,10 @@ func (b *build) Run(ctx context.Context, ui packersdk.Ui) ([]packersdk.Artifact,
 	nextId := b.mux.NextId()
 	server := newServerWithMux(b.mux, nextId)
 	server.RegisterUi(ui)
-	go server.Serve()
+	go func() {
+		defer server.Close()
+		server.Serve()
+	}()
 
 	done := make(chan interface{})
 	defer close(done)
@@ -74,12 +77,16 @@ func (b *build) Run(ctx context.Context, ui packersdk.Ui) ([]packersdk.Artifact,
 	}
 
 	artifacts := make([]packersdk.Artifact, len(result))
+	clients := make([]*Client, 0, len(result))
 	for i, streamId := range result {
 		client, err := newClientWithMux(b.mux, streamId)
 		if err != nil {
+			for _, c := range clients {
+				c.Close()
+			}
 			return nil, err
 		}
-
+		clients = append(clients, client)
 		artifacts[i] = client.Artifact()
 	}
 
@@ -145,7 +152,10 @@ func (b *BuildServer) Run(streamId uint32, reply *[]uint32) error {
 		streamId := b.mux.NextId()
 		server := newServerWithMux(b.mux, streamId)
 		server.RegisterArtifact(artifact)
-		go server.Serve()
+		go func() {
+			defer server.Close()
+			server.Serve()
+		}()
 
 		(*reply)[i] = streamId
 	}

--- a/rpc/builder.go
+++ b/rpc/builder.go
@@ -59,7 +59,10 @@ func (b *builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	server := newServerWithMux(b.mux, nextId)
 	server.RegisterHook(hook)
 	server.RegisterUi(ui)
-	go server.Serve()
+	go func() {
+		defer server.Close()
+		server.Serve()
+	}()
 
 	done := make(chan interface{})
 	defer close(done)
@@ -130,7 +133,10 @@ func (b *BuilderServer) Run(streamId uint32, reply *uint32) error {
 		if err != nil {
 			return err
 		}
-		go artifactServer.Serve()
+		go func() {
+			defer artifactServer.Close()
+			artifactServer.Serve()
+		}()
 		*reply = streamId
 	}
 

--- a/rpc/hook.go
+++ b/rpc/hook.go
@@ -39,7 +39,10 @@ func (h *hook) Run(ctx context.Context, name string, ui packersdk.Ui, comm packe
 	server := newServerWithMux(h.mux, nextId)
 	server.RegisterCommunicator(comm)
 	server.RegisterUi(ui)
-	go server.Serve()
+	go func() {
+		defer server.Close()
+		server.Serve()
+	}()
 
 	done := make(chan interface{})
 	defer close(done)

--- a/rpc/post_processor.go
+++ b/rpc/post_processor.go
@@ -51,7 +51,10 @@ func (p *postProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, a pack
 	server := newServerWithMux(p.mux, nextId)
 	server.RegisterArtifact(a)
 	server.RegisterUi(ui)
-	go server.Serve()
+	go func() {
+		defer server.Close()
+		server.Serve()
+	}()
 
 	done := make(chan interface{})
 	defer close(done)
@@ -136,7 +139,10 @@ func (p *PostProcessorServer) PostProcess(streamId uint32, reply *PostProcessorP
 		if err := server.RegisterArtifact(artifactResult); err != nil {
 			return err
 		}
-		go server.Serve()
+		go func() {
+			defer server.Close()
+			server.Serve()
+		}()
 	}
 	return nil
 }

--- a/rpc/provisioner.go
+++ b/rpc/provisioner.go
@@ -49,7 +49,10 @@ func (p *provisioner) Provision(ctx context.Context, ui packersdk.Ui, comm packe
 	server := newServerWithMux(p.mux, nextId)
 	server.RegisterCommunicator(comm)
 	server.RegisterUi(ui)
-	go server.Serve()
+	go func() {
+		defer server.Close()
+		server.Serve()
+	}()
 
 	done := make(chan interface{})
 	defer close(done)


### PR DESCRIPTION
### Description

Resolved potential resource leaks by adding `defer ...Close()` calls across file, temp file, device, SSH, and plugin server lifecycles to prevent resource leaks; and closing RPC `Serve()` goroutines on exit.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.