### PR TITLE
refactor: use context-aware call

### DIFF
--- a/sdk-internals/communicator/winrm/communicator.go
+++ b/sdk-internals/communicator/winrm/communicator.go
@@ -132,7 +132,7 @@ func (c *Communicator) Download(src string, dst io.Writer) error {
 	base64DecodePipe := &Base64Pipe{w: dst}
 
 	cmd := winrm.Powershell(fmt.Sprintf(encodeScript, src))
-	_, err = client.Run(cmd, base64DecodePipe, io.Discard)
+	_, err = client.RunWithContext(context.Background(), cmd, base64DecodePipe, io.Discard)
 
 	return err
 }


### PR DESCRIPTION
### Description

Updates the WinRM file downloads to call `RunWithContext` with `context.Background()` instead of the deprecated `Run`. 

This aligns the communicator with the context-aware client API and prepares the path for cancellation/timeouts without changing current behavior.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.
