### PR TITLE
refactor: use pointer receivers on all `scpUploadState` methods

### DIFF
--- a/adapter/scp.go
+++ b/adapter/scp.go
@@ -135,11 +135,11 @@ type scpUploadState struct {
 	targetIsDir bool
 }
 
-func (scp scpUploadState) DestPath() string {
+func (scp *scpUploadState) DestPath() string {
 	return filepath.Join(scp.target, scp.dir)
 }
 
-func (scp scpUploadState) SrcPath() string {
+func (scp *scpUploadState) SrcPath() string {
 	return filepath.Join(scp.srcRoot, scp.dir)
 }
 


### PR DESCRIPTION
### Description

Updates the method receivers for `DestPath` and `SrcPath` in the `scpUploadState` struct to use pointer receivers instead of value receivers. This change ensures consistency and allows these methods to work correctly if the struct is modified in the future. No other significant logic changes are introduced.

Both `DestPath` and `SrcPath` methods were the only methods on `scpUploadState` that used a value receiver. They only read fields, so behavior does not change. The other methods already use a pointer because they update the session. Using the same receiver on every method avoids mixing styles and makes it clear these helpers run on the same state, not a copy.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.
