### PR TITLE
refactor: rename shadowed vars for clarity

### DIFF
--- a/cmd/packer-sdc/internal/mapstructure-to-hcl2/mapstructure-to-hcl2.go
+++ b/cmd/packer-sdc/internal/mapstructure-to-hcl2/mapstructure-to-hcl2.go
@@ -472,8 +472,8 @@ func uniqueTags(tagName string, fields []*types.Var, tags []string) ([]*types.Va
 	uniqueTags := map[string]bool{}
 	for i := range fields {
 		field, tag := fields[i], tags[i]
-		structtag, _ := structtag.Parse(tag)
-		h, err := structtag.Get(tagName)
+		st, _ := structtag.Parse(tag)
+		h, err := st.Get(tagName)
 		if err == nil {
 			if uniqueTags[h.Name] {
 				return nil, nil, fmt.Errorf("field %q: duplicate tag %q", field.Name(), tagName)
@@ -498,14 +498,14 @@ func getMapstructureSquashedStruct(topPkg *types.Package, utStruct *types.Struct
 		if _, ok := field.Type().(*types.Signature); ok {
 			continue // ignore funcs
 		}
-		structtag, err := structtag.Parse(tag)
+		st, err := structtag.Parse(tag)
 		if err != nil {
 			log.Printf("could not parse field tag %s of : %v", tag, err)
 			continue
 		}
 
 		// Contains mapstructure-to-hcl2 tag
-		if ms, err := structtag.Get("mapstructure-to-hcl2"); err == nil {
+		if ms, err := st.Get("mapstructure-to-hcl2"); err == nil {
 			// Stop if is telling to skip it
 			if ms.HasOption("skip") {
 				continue
@@ -513,7 +513,7 @@ func getMapstructureSquashedStruct(topPkg *types.Package, utStruct *types.Struct
 		}
 
 		// Contains mapstructure tag
-		if ms, err := structtag.Get("mapstructure"); err == nil {
+		if ms, err := st.Get("mapstructure"); err == nil {
 			// Squash structs
 			if ms.HasOption("squash") {
 				ot := field.Type()

--- a/cmd/packer-sdc/internal/renderdocs/renderdocs.go
+++ b/cmd/packer-sdc/internal/renderdocs/renderdocs.go
@@ -30,11 +30,11 @@ type Command struct {
 }
 
 func (cmd *Command) Flags() *flag.FlagSet {
-	fs := flag.NewFlagSet(cmdPrefix, flag.ExitOnError)
-	fs.StringVar(&cmd.SrcDir, "src", "docs-src", "folder to copy docs from.")
-	fs.StringVar(&cmd.PartialsDir, "partials", "docs-partials", "folder containing all mdx partials.")
-	fs.StringVar(&cmd.DstDir, "dst", "docs-rendered", "output folder.")
-	return fs
+	flags := flag.NewFlagSet(cmdPrefix, flag.ExitOnError)
+	flags.StringVar(&cmd.SrcDir, "src", "docs-src", "folder to copy docs from.")
+	flags.StringVar(&cmd.PartialsDir, "partials", "docs-partials", "folder containing all mdx partials.")
+	flags.StringVar(&cmd.DstDir, "dst", "docs-rendered", "output folder.")
+	return flags
 }
 
 func (cmd *Command) Help() string {

--- a/guestexec/elevated.go
+++ b/guestexec/elevated.go
@@ -178,8 +178,8 @@ func GenerateElevatedRunner(command string, p ElevatedProvisioner) (uploadedPath
 			elevatedPassword, escapedElevatedPassword)
 	}
 
-	uuid := uuid.TimeOrderedUUID()
-	path := fmt.Sprintf(`C:/Windows/Temp/packer-elevated-shell-%s.ps1`, uuid)
+	shellID := uuid.TimeOrderedUUID()
+	path := fmt.Sprintf(`C:/Windows/Temp/packer-elevated-shell-%s.ps1`, shellID)
 
 	// Generate command
 	err = elevatedTemplate.Execute(&buffer, elevatedOptions{

--- a/multistep/commonsteps/step_create_floppy.go
+++ b/multistep/commonsteps/step_create_floppy.go
@@ -126,13 +126,13 @@ func (s *StepCreateFloppy) Run(ctx context.Context, state multistep.StateBag) mu
 	}
 
 	var crawlDirectoryFiles []string
-	crawlDirectory := func(path string, info os.FileInfo, err error) error {
+	crawlDirectory := func(pathname string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 		if !info.IsDir() {
-			crawlDirectoryFiles = append(crawlDirectoryFiles, path)
-			ui.Message(fmt.Sprintf("Adding file: %s", path))
+			crawlDirectoryFiles = append(crawlDirectoryFiles, pathname)
+			ui.Message(fmt.Sprintf("Adding file: %s", pathname))
 		}
 		return nil
 	}
@@ -218,8 +218,8 @@ func (s *StepCreateFloppy) Run(ctx context.Context, state multistep.StateBag) mu
 
 	// Collect files from floppy_content
 	ui.Message("Copying files from floppy_content")
-	for path, content := range s.Content {
-		err = s.AddContent(cache, path, content)
+	for contentPath, content := range s.Content {
+		err = s.AddContent(cache, contentPath, content)
 		if err != nil {
 			state.Put("error",
 				fmt.Errorf("Error creating file for floppy: %s", err))
@@ -318,9 +318,9 @@ func (s *StepCreateFloppy) Add(dircache directoryCache, src string) error {
 	return filepath.Walk(src, visit)
 }
 
-func (s *StepCreateFloppy) AddContent(dircache directoryCache, path, content string) error {
-	basedirectory := filepath.Join(path, "..")
-	directory, filename := filepath.Split(filepath.ToSlash(path))
+func (s *StepCreateFloppy) AddContent(dircache directoryCache, contentPath, content string) error {
+	basedirectory := filepath.Join(contentPath, "..")
+	directory, filename := filepath.Split(filepath.ToSlash(contentPath))
 
 	base, err := removeBase(basedirectory, filepath.FromSlash(directory))
 	if err != nil {
@@ -344,9 +344,9 @@ func (s *StepCreateFloppy) AddContent(dircache directoryCache, path, content str
 
 	_, err = io.WriteString(fatFile, content)
 	if err != nil {
-		return fmt.Errorf("Error writing file %s on floppy: %s", path, err)
+		return fmt.Errorf("Error writing file %s on floppy: %s", contentPath, err)
 	}
-	s.FilesAdded[path] = true
+	s.FilesAdded[contentPath] = true
 
 	return nil
 }
@@ -361,26 +361,26 @@ func (s *StepCreateFloppy) Cleanup(multistep.StateBag) {
 // removeBase will take a regular os.PathSeparator-separated path and remove the
 // prefix directory base from it. Both paths are converted to their absolute
 // formats before the stripping takes place.
-func removeBase(base string, path string) (string, error) {
+func removeBase(base string, pathname string) (string, error) {
 	var idx int
 	var err error
 
-	if res, err := filepath.Abs(path); err == nil {
-		path = res
+	if res, err := filepath.Abs(pathname); err == nil {
+		pathname = res
 	}
-	path = filepath.Clean(path)
+	pathname = filepath.Clean(pathname)
 
 	if base, err = filepath.Abs(base); err != nil {
-		return path, err
+		return pathname, err
 	}
 
-	c1, c2 := strings.Split(base, string(os.PathSeparator)), strings.Split(path, string(os.PathSeparator))
+	c1, c2 := strings.Split(base, string(os.PathSeparator)), strings.Split(pathname, string(os.PathSeparator))
 	for idx = 0; idx < len(c1); idx++ {
 		if len(c1[idx]) == 0 && len(c2[idx]) != 0 {
 			break
 		}
 		if c1[idx] != c2[idx] {
-			return "", fmt.Errorf("Path %s is not prefixed by Base %s", path, base)
+			return "", fmt.Errorf("Path %s is not prefixed by Base %s", pathname, base)
 		}
 	}
 	return strings.Join(c2[idx:], string(os.PathSeparator)), nil
@@ -418,10 +418,10 @@ func fsDirectoryCache(rootDirectory fs.Directory) directoryCache {
 			for i := range component {
 
 				// join all of our components into a key
-				path := strings.Join(component[:i], "/")
+				dirPath := strings.Join(component[:i], "/")
 
 				// check if parent directory is cached
-				res, ok = cache[path]
+				res, ok = cache[dirPath]
 				if !ok {
 					// add directory into cache
 					directory, err := entry.AddDirectory(component[i-1])
@@ -434,7 +434,7 @@ func fsDirectoryCache(rootDirectory fs.Directory) directoryCache {
 						Error <- err
 						continue
 					}
-					cache[path] = res
+					cache[dirPath] = res
 				}
 				// cool, found a directory
 				entry = res

--- a/multistep/commonsteps/step_create_floppy_test.go
+++ b/multistep/commonsteps/step_create_floppy_test.go
@@ -305,9 +305,9 @@ func TestStepCreateFloppyContent(t *testing.T) {
 	}
 
 	// check the FilesAdded array to see if it matches
-	for path := range step.Content {
-		if !step.FilesAdded[path] {
-			t.Fatalf("unable to find file: %s for %v", path, step.Content)
+	for filename := range step.Content {
+		if !step.FilesAdded[filename] {
+			t.Fatalf("unable to find file: %s for %v", filename, step.Content)
 		}
 	}
 

--- a/multistep/commonsteps/step_http_server.go
+++ b/multistep/commonsteps/step_http_server.go
@@ -62,16 +62,16 @@ func (s *StepHTTPServer) Handler() http.Handler {
 type MapServer map[string]string
 
 func (s MapServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	path := path.Clean(r.URL.Path)
-	content, found := s[path]
+	urlPath := path.Clean(r.URL.Path)
+	content, found := s[urlPath]
 	if !found {
 		paths := make([]string, 0, len(s))
 		for k := range s {
 			paths = append(paths, k)
 		}
 		sort.Strings(paths)
-		err := fmt.Sprintf("%s not found.", path)
-		if sug := didyoumean.NameSuggestion(path, paths); sug != "" {
+		err := fmt.Sprintf("%s not found.", urlPath)
+		if sug := didyoumean.NameSuggestion(urlPath, paths); sug != "" {
 			err += fmt.Sprintf(" Did you mean %q?", sug)
 		}
 

--- a/packer/multi_error_test.go
+++ b/packer/multi_error_test.go
@@ -21,12 +21,12 @@ func TestMultiErrorError(t *testing.T) {
 * foo
 * bar`
 
-	errors := []error{
+	errs := []error{
 		errors.New("foo"),
 		errors.New("bar"),
 	}
 
-	multi := &MultiError{errors}
+	multi := &MultiError{errs}
 	if multi.Error() != expected {
 		t.Fatalf("bad: %s", multi.Error())
 	}


### PR DESCRIPTION
### Description

This refactor renames several local variables that were shadowing imported package names or using ambiguous names (for example `structtag`, `path`, `uuid`, and `errors`). 

It improves readability and avoids confusion in helper methods and tests without changing behavior.

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.
